### PR TITLE
Validation of Earnings and Benefits page

### DIFF
--- a/app/controllers/earnings_and_benefits_controller.rb
+++ b/app/controllers/earnings_and_benefits_controller.rb
@@ -8,6 +8,8 @@ class EarningsAndBenefitsController < ApplicationController
     if @earnings_and_benefits.valid?
       current_store.hash_store[:earnings_and_benefits_answers] = @earnings_and_benefits.to_h
       redirect_to edit_response_path
+    else
+      render :edit
     end
   end
 

--- a/app/forms/earnings_and_benefits.rb
+++ b/app/forms/earnings_and_benefits.rb
@@ -26,4 +26,19 @@ class EarningsAndBenefits < BaseForm
       disagree_claimant_pension_benefits_reason: disagree_claimant_pension_benefits_reason
     }
   end
+
+  validates :queried_hours, :queried_pay_before_tax, :queried_take_home_pay,
+    numericality: true,
+    allow_nil: true
+  validates :disagree_claimant_notice_reason,
+    length: {
+      maximum: 400,
+      too_long: "%{count} characters is the maximum allowed" # rubocop:disable Style/FormatStringToken
+    }
+  validates :disagree_claimant_pension_benefits_reason,
+    length: {
+      maximum: 350,
+      too_long: "%{count} characters is the maximum allowed" # rubocop:disable Style/FormatStringToken
+    }
+
 end

--- a/app/views/earnings_and_benefits/edit.html.slim
+++ b/app/views/earnings_and_benefits/edit.html.slim
@@ -1,118 +1,52 @@
-/ TODO: Add required fields
-/ TODO: Check if there are "hidden" elements on the Jadu form
 .content-body.earnings-and-benefits
   - content_for :form_page_title do
     = "Earnings and Benefits"
 
   = form_for @earnings_and_benefits, url: earnings_and_benefits_path, method: :patch  do |f|
-    #question1.form-group
-      fieldset
-        legend
-          h1.heading-medium Are the claimant's hours of work correct?
-        / Radio button for 'Yes'
-        .multiple-choice
-          = f.radio_button(:agree_with_claimants_hours, true, class: 'form-control')
-          = f.label(:agree_with_claimants_hours_true, 'Yes', class: 'form-label')
-        / Radio button for 'No'
-        .multiple-choice data-target="disagree_claimants_hours"
-          = f.radio_button(:agree_with_claimants_hours, false, class: 'form-control')
-          = f.label(:agree_with_claimants_hours_false, 'No', class: 'form-label')
-        / Hidden field for disagreement reason, shows when radio button is clicked
-        #disagree_claimants_hours.panel.panel-border-narrow.js-hidden
-          = f.label(:queried_hours, 'Please enter the details you believe to be correct', class: 'form-label')
-          = f.text_field(:queried_hours, class: 'form-control')
-          span hours each week
-    #question2.form-group
-      fieldset
-        legend
-          h1.heading-medium Are the earnings details given by the claimant correct?
-        / Radio button for 'Yes'
-        .multiple-choice
-          = f.radio_button(:agree_with_earnings_details, true, class: 'form-control')
-          = f.label(:agree_with_earnings_details_true, 'Yes', class: 'form-label')
-        / Radio button for 'No'
-        .multiple-choice data-target="disagree_earnings_details"
-          = f.radio_button(:agree_with_earnings_details, false, class: 'form-control')
-          = f.label(:agree_with_earnings_details_false, 'No', class: 'form-label')
-          span If No, please give the details you believe to be correct
-        / Hidden wrapper for correcting claimant's details, shows when radio button is clicked
-        #disagree_earnings_details.panel.panel-border-narrow.js-hidden
-          / Wrapper for 'Pay Before Tax Questions'
-          .pay-before-tax
-            / Text input for financial value
-            fieldset
-              legend
-                h2.heading-medium Pay before tax
-              .form-group
-                = f.label(:queried_pay_before_tax, 'Pay before tax', class: 'form-label')
-                = f.text_field(:queried_pay_before_tax, class: 'form-control')
-                span Incl. overtime, commission, bonuses, etc.
-            / Radio buttons for period selection
-            fieldset
-              legend
-                h2.heading-medium Pay before tax period
-              / Monthly
-              .multiple-choice
-                = f.radio_button(:queried_pay_before_tax_period, 'Monthly', class: 'form-control')
-                = f.label(:queried_pay_before_tax_period_monthly, 'Monthly', class: 'form-label')
-              / Weekly
-              .multiple-choice
-                = f.radio_button(:queried_pay_before_tax_period, 'Weekly', class: 'form-control')
-                = f.label(:queried_pay_before_tax_period_weekly, 'Weekly', class: 'form-label')
-          / Wrapper for 'Normal Take Home Pay Questions'
-          .normal-take-home-pay
-            / Text input for financial value
-            fieldset
-              legend
-                h2.heading-medium Normal take-home pay
-              .form-group
-                = f.label(:queried_take_home_pay, 'Normal take-home pay', class: 'form-label')
-                = f.text_field(:queried_take_home_pay, class: 'form-control')
-                span Incl. overtime, commission, bonuses, etc.
-            / Radio buttons for period selection
-            fieldset
-              legend
-                h2.heading-medium Normal take-home pay period
-              / Monthly
-              .multiple-choice
-                = f.radio_button(:queried_take_home_pay_period, 'Monthly', class: 'form-control')
-                = f.label(:queried_take_home_pay_period_monthly, 'Monthly', class: 'form-label')
-              / Weekly
-              .multiple-choice
-                = f.radio_button(:queried_take_home_pay_period, 'Weekly', class: 'form-control')
-                = f.label(:queried_take_home_pay_period_weekly, 'Weekly', class: 'form-label')
-    #question3.form-group
-      fieldset
-        legend
-          h1.heading-medium Is the information given by the claimant correct about being paid for, or working a period of notice? 
-        / Radio button for 'Yes'
-        .multiple-choice
-          = f.radio_button(:agree_with_claimant_notice, true, class: 'form-control')
-          = f.label(:agree_with_claimant_notice_true, 'Yes', class: 'form-label')
-        / Radio button for 'No'
-        .multiple-choice data-target="disagree_claimant_notice"
-          = f.radio_button(:agree_with_claimant_notice, false, class: 'form-control')
-          = f.label(:agree_with_claimant_notice_false, 'No', class: 'form-label')
-        / Hidden field for disagreement reason, shows when radio button is clicked
-        #disagree_claimant_notice.panel.panel-border-narrow.js-hidden
-          = f.label(:disagree_claimant_notice_reason, 'Please give the details you believe to be correct below. If you didn\'t give notice or pay them instead of letting them work their notice please explain what happened and why', class: 'form-label')
-          = f.text_area(:disagree_claimant_notice_reason, class: 'form-control')
-          span PLEASE NOTE – You will only be able to enter a limited amount of information here (up to 400 characters) if you would like to include more please use our upload facility at the end of this form where you will be able to upload a Rich Text Format (.rtf) file.
-    #question4.form-group
-      fieldset
-        legend
-          h1.heading-medium Are the details about pension and other benefits e.g. company car, medical insurance, etc. given by the claimant correct?
-        / Radio button for 'Yes'
-        .multiple-choice
-          = f.radio_button(:agree_with_claimant_pension_benefits, true, class: 'form-control')
-          = f.label(:agree_with_claimant_pension_benefits_true, 'Yes', class: 'form-label')
-        / Radio button for 'No'
-        .multiple-choice data-target="disagree_claimant_pension_benefits"
-          = f.radio_button(:agree_with_claimant_pension_benefits, false, class: 'form-control')
-          = f.label(:agree_with_claimant_pension_benefits_false, 'No', class: 'form-label')
-        / Hidden field for disagreement reason, shows when radio button is clicked
-        #disagree_claimant_pension_benefits.panel.panel-border-narrow.js-hidden
-          = f.label(:disagree_claimant_pension_benefits_reason, 'Please give the details you believe to be correct.', clas: 'form-label')
-          = f.text_area(:disagree_claimant_pension_benefits_reason, class: 'form-control')
-          span PLEASE NOTE – You will only be able to enter a limited amount of information here (up to 350 characters) if you would like to include more please use our upload facility at the end of this form where you will be able to upload a Rich Text Format (.rtf) file.
+
+    = GovukElementsErrorsHelper.error_summary @earnings_and_benefits,
+    "Please review the following",
+    "Optional description of the errors and how to correct them"
+
+    = f.radio_button_fieldset :agree_with_claimants_hours do |b|
+      = content_tag :div, {class: 'multiple-choice'} do
+        = b.radio_button(:agree_with_claimants_hours, true) + label(:agree_with_claimants_hours_true, t('helpers.label.earnings_and_benefits.agree_with_claimants_hours.choices.yes'), value: :yes)
+      = content_tag :div, {class: 'multiple-choice', data: { target: :disagree_claimants_hours }} do
+        = b.radio_button(:agree_with_claimants_hours, false) + label(:agree_with_claimants_hours_false, t('helpers.label.earnings_and_benefits.agree_with_claimants_hours.choices.no'), value: :no)
+      #disagree_claimants_hours.panel.panel-border-narrow.js-hidden
+        = f.text_field :queried_hours
+    = f.radio_button_fieldset :agree_with_earnings_details do |b|
+      = content_tag :div, {class: 'multiple-choice'} do
+        = b.radio_button(:agree_with_earnings_details, true) + label(:agree_with_earnings_details_true, t('helpers.label.earnings_and_benefits.agree_with_earnings_details.choices.yes'), value: :yes)
+      = content_tag :div, {class: 'multiple-choice', data: {target: :disagree_earnings_details }} do
+        = b.radio_button(:agree_with_earnings_details, false) + label(:agree_with_earnings_details_false, t('helpers.label.earnings_and_benefits.agree_with_earnings_details.choices.no'), value: :no)
+      #disagree_earnings_details.panel.panel-border-narrow.js-hidden
+        = content_tag :div, {class: 'pay-before-tax'} do
+          = f.text_field :queried_pay_before_tax
+          = f.radio_button_fieldset :queried_pay_before_tax_period do |c|
+            = content_tag :div, {class: 'multiple-choice'} do
+              = c.radio_button(:queried_pay_before_tax_period, 'Monthly') + label(:queried_pay_before_tax_period_monthly, t('helpers.label.earnings_and_benefits.queried_pay_before_tax_period.choices.monthly'), value: :monthly)
+            = content_tag :div, {class: 'multiple-choice'} do
+              = c.radio_button(:queried_pay_before_tax_period, 'Weekly') + label(:queried_pay_before_tax_period_weekly, t('helpers.label.earnings_and_benefits.queried_pay_before_tax_period.choices.weekly'), value: :weekly)
+        = content_tag :div, {class: 'normal-take-home-pay'} do
+          = f.text_field :queried_take_home_pay
+          = f.radio_button_fieldset :queried_take_home_pay_period do |c|
+            = content_tag :div, {class: 'multiple-choice'} do
+              = c.radio_button(:queried_take_home_pay_period, 'Monthly') + label(:queried_take_home_pay_period_monthly, t('helpers.label.earnings_and_benefits.queried_take_home_pay_period.choices.monthly'), value: :monthly)
+            = content_tag :div, {class: 'multiple-choice'} do
+              = c.radio_button(:queried_take_home_pay_period, 'Weekly') + label(:queried_take_home_pay_period_weekly, t('helpers.label.earnings_and_benefits.queried_take_home_pay_period.choices.weekly'), value: :weekly)
+    = f.radio_button_fieldset :agree_with_claimant_notice do |b|
+      = content_tag :div, {class: 'multiple-choice'} do
+        = b.radio_button(:agree_with_claimant_notice, true) + label(:agree_with_claimant_notice_true, t('helpers.label.earnings_and_benefits.agree_with_claimant_notice.choices.yes'), value: :yes)
+      = content_tag :div, {class: 'multiple-choice', data: {target: :disagree_claimant_notice }} do
+        = b.radio_button(:agree_with_claimant_notice, false) + label(:agree_with_claimant_notice_false, t('helpers.label.earnings_and_benefits.agree_with_claimant_notice.choices.no'), value: :no)
+      #disagree_claimant_notice.panel.panel-border-narrow.js-hidden
+        = f.text_area :disagree_claimant_notice_reason
+    = f.radio_button_fieldset :agree_with_claimant_pension_benefits do |b|
+      = content_tag :div, {class: 'multiple-choice'} do
+        = b.radio_button(:agree_with_claimant_pension_benefits, true) + label(:agree_with_claimant_pension_benefits_true, t('helpers.label.earnings_and_benefits.agree_with_claimant_pension_benefits.choices.yes'), value: :yes)
+      = content_tag :div, {class: 'multiple-choice', data: {target: :disagree_claimant_pension_benefits }} do
+        = b.radio_button(:agree_with_claimant_pension_benefits, false) + label(:agree_with_claimant_pension_benefits_false, t('helpers.label.earnings_and_benefits.agree_with_claimant_pension_benefits.choices.no'), value: :no)
+      #disagree_claimant_pension_benefits.panel.panel-border-narrow.js-hidden
+        = f.text_area :disagree_claimant_pension_benefits_reason
     = f.submit("Save and continue", class: 'button')

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -41,6 +41,13 @@ en:
         agree_with_employment_dates: Are the dates of employment given by the claimant correct?
         continued_employment: Is their employment continuing? (optional)
         agree_with_claimants_description_of_job_or_title: Is the claimant's description of their job or job title correct? (optional)
+      earnings_and_benefits:
+        agree_with_claimants_hours: Are the claimant's hours of work correct? (optional)
+        agree_with_earnings_details: Are the earnings details given by the claimant correct? (optional)
+        queried_pay_before_tax_period: Pay before tax period (optional)
+        queried_take_home_pay_period: Normal take-home pay period (optional)
+        agree_with_claimant_notice: Is the information given by the claimant correct about being paid for, or working a period of notice? (optional)
+        agree_with_claimant_pension_benefits: Are the details about pension and other benefits given by the claimant correct? (optional)
     label:
       respondents_detail:
         case_number: Case Number
@@ -90,9 +97,51 @@ en:
             'yes': 'Yes'
             'no': 'No'
         disagree_claimants_job_or_title: Please give the details you believe to be correct (optional)
+      earnings_and_benefits:
+        agree_with_claimants_hours:
+          choices:
+            'yes': 'Yes'
+            'no': 'No'
+        queried_hours: Please enter the details you believe to be correct (optional)
+        agree_with_earnings_details:
+          choices:
+            'yes': 'Yes'
+            'no': 'No'
+        queried_pay_before_tax: Pay before tax (optional)
+        queried_pay_before_tax_period:
+          choices:
+            monthly: Monthly
+            weekly: Weekly
+        queried_take_home_pay: Normal take-home pay (optional)
+        queried_take_home_pay_period:
+          choices:
+            monthly: Monthly
+            weekly: Weekly
+        agree_with_claimant_notice:
+          choices:
+            'yes': 'Yes'
+            'no': 'No'
+        disagree_claimant_notice_reason: |
+          Please give the details you believe to be correct below. If you didn't give notice or pay them instead of letting them work their notice please explain what happened and why (optional)
+        agree_with_claimant_pension_benefits:
+          choices:
+            'yes': 'Yes'
+            'no': 'No'
+        disagree_claimant_pension_benefits_reason:
+          Please give the details you believe to be correct. (optional)
     hint:
       respondents_detail:
         mobile_number: If different to your primary contact number
+      earnings_and_benefits:
+        queried_hours: In hours per week
+        agree_with_earnings_details: If No, please give the details you believe to be correct
+        queried_pay_before_tax: Including overtime, commission, bonuses, etc.
+        queried_take_home_pay: Including overtime, commission, bonuses, etc.
+        disagree_claimant_notice_reason: |
+          PLEASE NOTE – You will only be able to enter a limited amount of information here (up to 400 characters) if you would like to include more please use our upload facility at the end of this form where you will be able to upload a Rich Text Format (.rtf) file.
+        agree_with_claimant_pension_benefits: "For example: company car, medical insurance, etc."
+        disagree_claimant_pension_benefits_reason: |
+          PLEASE NOTE – You will only be able to enter a limited amount of information here (up to 350 characters) if you would like to include more please use our upload facility at the end of this form where you will be able to upload a Rich Text Format (.rtf) file.
   errors:
     messages:
       contains_no_spaces: must contain spaces

--- a/spec/features/fill_in_earnings_and_benefits_page_spec.rb
+++ b/spec/features/fill_in_earnings_and_benefits_page_spec.rb
@@ -31,7 +31,9 @@ RSpec.feature "Fill in Earnings and Benefits Page", js: true do
 
     expect(earnings_and_benefits_page).to have_error_header
     expect(earnings_and_benefits_page.agree_with_claimants_hours_question).to have_error_not_a_number
-    expect(earnings_and_benefits_page.agree_with_earnings_detail_question).to have_error_not_a_number
-    expect(earnings_and_benefits_page.agree_with_earnings_detail_question).to have_error_not_a_number
+    expect(earnings_and_benefits_page.agree_with_earnings_details_question).to have_error_not_a_number
+    expect(earnings_and_benefits_page.agree_with_earnings_details_question).to have_error_not_a_number
+    expect(earnings_and_benefits_page.agree_with_claimant_notice_question).to have_error_too_long
+    expect(earnings_and_benefits_page.agree_with_claimant_pension_benefits_question).to have_error_too_long
   end
 end

--- a/spec/features/fill_in_earnings_and_benefits_page_spec.rb
+++ b/spec/features/fill_in_earnings_and_benefits_page_spec.rb
@@ -16,4 +16,22 @@ RSpec.feature "Fill in Earnings and Benefits Page", js: true do
 
     expect(response_page).to be_displayed
   end
+
+  scenario "incorrectly will provide many errors" do
+    earnings_and_benefits_page.load
+
+    given_i_am(:erroneously_entering_data)
+
+    answer_agree_with_claimants_hours_question
+    answer_agree_with_earnings_details_question
+    answer_agree_with_claimant_notice_question
+    answer_agree_with_claimant_pension_benefits_question
+
+    earnings_and_benefits_page.next
+
+    expect(earnings_and_benefits_page).to have_error_header
+    expect(earnings_and_benefits_page.agree_with_claimants_hours_question).to have_error_not_a_number
+    expect(earnings_and_benefits_page.agree_with_earnings_detail_question).to have_error_not_a_number
+    expect(earnings_and_benefits_page.agree_with_earnings_detail_question).to have_error_not_a_number
+  end
 end

--- a/spec/forms/earnings_and_benefits_spec.rb
+++ b/spec/forms/earnings_and_benefits_spec.rb
@@ -2,147 +2,241 @@ require 'rails_helper'
 
 RSpec.describe EarningsAndBenefits, type: :model do
 
+  let(:populated_earnings_and_benefits) {
+    described_class.new(
+      agree_with_claimants_hours: false,
+      queried_hours: 20.5,
+      agree_with_earnings_details: false,
+      queried_pay_before_tax: 900.25,
+      queried_pay_before_tax_period: 'weekly',
+      queried_take_home_pay: 100.50,
+      queried_take_home_pay_period: 'weekly',
+      agree_with_claimant_notice: false,
+      disagree_claimant_notice_reason: 'lorem ipsum notice',
+      agree_with_claimant_pension_benefits: false,
+      disagree_claimant_pension_benefits_reason: 'lorem ipsum pension'
+    )
+  }
+
+  let(:four_hundred_and_one_chars) {
+    'Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa.
+    Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Donec quam felis,
+    ultricies nec, pellentesque eu, pretium quis, sem. Nulla consequat massa quis enim. Donec pede justo,
+    fringilla vel, aliquet nec, vulputate eget, arcu. In enim justo, rhoncus ut, imperdiet a,'
+  }
+
+  let(:three_hundred_fifty_one_chars) {
+    'Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa.
+    Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Donec quam felis,
+    ultricies nec, pellentesque eu, pretium quis, sem. Nulla consequat massa quis enim. Donec pede justo,
+    fringilla vel, aliquet nec, vulputate e'
+  }
+
+  context 'with validators' do
+    it 'will not validate queried hours with a string' do
+      populated_earnings_and_benefits.queried_hours = 'string'
+
+      populated_earnings_and_benefits.valid?
+
+      expect(populated_earnings_and_benefits.errors.details[:queried_hours]).to include a_hash_including(error: :not_a_number)
+    end
+
+    it 'will not validate queried pay before tax with a string' do
+      populated_earnings_and_benefits.queried_pay_before_tax = 'string'
+
+      populated_earnings_and_benefits.valid?
+
+      expect(populated_earnings_and_benefits.errors.details[:queried_pay_before_tax]).to include a_hash_including(error: :not_a_number)
+    end
+
+    it 'will not validate queried take home pay with a string' do
+      populated_earnings_and_benefits.queried_take_home_pay = 'string'
+
+      populated_earnings_and_benefits.valid?
+
+      expect(populated_earnings_and_benefits.errors.details[:queried_take_home_pay]).to include a_hash_including(error: :not_a_number)
+    end
+
+    it 'will not validate disagree claimant reason over 400 characters' do
+      populated_earnings_and_benefits.disagree_claimant_notice_reason = four_hundred_and_one_chars
+
+      populated_earnings_and_benefits.valid?
+
+      expect(populated_earnings_and_benefits.errors.details[:disagree_claimant_notice_reason]).to include a_hash_including(error: :too_long)
+    end
+
+    it 'will not validate disagree pension benefits reason over 350 characters' do
+      populated_earnings_and_benefits.disagree_claimant_pension_benefits_reason = three_hundred_fifty_one_chars
+
+      populated_earnings_and_benefits.valid?
+
+      expect(populated_earnings_and_benefits.errors.details[:disagree_claimant_pension_benefits_reason]).to include a_hash_including(error: :too_long)
+    end
+  end
+
   context 'when correctly populated' do
 
-    it 'agree with claimants hours only' do
-      earnings_and_benefits = described_class.new(agree_with_claimants_hours: true)
-
-      expect(earnings_and_benefits.agree_with_claimants_hours).to be true
+    it 'returns the correct claimants hours' do
+      expect(populated_earnings_and_benefits.agree_with_claimants_hours).to be false
     end
 
-    it 'with queried hours only' do
-      earnings_and_benefits = described_class.new(queried_hours: 37.5)
-
-      expect(earnings_and_benefits.queried_hours).to be 37.5
+    it 'returns the correct queried hours' do
+      expect(populated_earnings_and_benefits.queried_hours).to be 20.5
     end
 
-    it 'agree with earnings details only' do
-      earnings_and_benefits = described_class.new(agree_with_earnings_details: true)
-
-      expect(earnings_and_benefits.agree_with_earnings_details).to be true
+    it 'returns the correct earnings details' do
+      expect(populated_earnings_and_benefits.agree_with_earnings_details).to be false
     end
 
-    it 'with queried_pay_before_tax only' do
-      earnings_and_benefits = described_class.new(queried_pay_before_tax: 100)
-
-      expect(earnings_and_benefits.queried_pay_before_tax).to be 100.00
+    it 'returns the correct queried_pay_before_tax' do
+      expect(populated_earnings_and_benefits.queried_pay_before_tax).to be 900.25
     end
 
-    it 'with queried_pay_before_tax_period only' do
-      earnings_and_benefits = described_class.new(queried_pay_before_tax_period: 'weekly')
-
-      expect(earnings_and_benefits.queried_pay_before_tax_period).to eql 'weekly'
+    it 'returns the correct queried_pay_before_tax_period' do
+      expect(populated_earnings_and_benefits.queried_pay_before_tax_period).to eql 'weekly'
     end
 
-    it 'with queried_take_home_pay only' do
-      earnings_and_benefits = described_class.new(queried_take_home_pay: 100)
-
-      expect(earnings_and_benefits.queried_take_home_pay).to be 100.00
+    it 'returns the correct queried_take_home_pay' do
+      expect(populated_earnings_and_benefits.queried_take_home_pay).to be 100.5
     end
 
-    it 'with queried_take_home_pay_period only' do
-      earnings_and_benefits = described_class.new(queried_take_home_pay_period: 'weekly')
-
-      expect(earnings_and_benefits.queried_take_home_pay_period).to eql 'weekly'
+    it 'returns the correct queried_take_home_pay_period' do
+      expect(populated_earnings_and_benefits.queried_take_home_pay_period).to eql 'weekly'
     end
 
-    it 'agree with claimant_notice only' do
-      earnings_and_benefits = described_class.new(agree_with_claimant_notice: true)
-
-      expect(earnings_and_benefits.agree_with_claimant_notice).to be true
+    it 'returns the correct claimant_notice' do
+      expect(populated_earnings_and_benefits.agree_with_claimant_notice).to be false
     end
 
-    it 'with disagree claimant notice reason' do
-      earnings_and_benefits = described_class.new(disagree_claimant_notice_reason: 'lorem ipsum notice')
-
-      expect(earnings_and_benefits.disagree_claimant_notice_reason).to eql 'lorem ipsum notice'
+    it 'returns the correct disagree claimant notice' do
+      expect(populated_earnings_and_benefits.disagree_claimant_notice_reason).to eql 'lorem ipsum notice'
     end
 
-    it 'agree with claimant_pension_benefits only' do
-      earnings_and_benefits = described_class.new(agree_with_claimant_pension_benefits: false)
-
-      expect(earnings_and_benefits.agree_with_claimant_pension_benefits).to be false
+    it 'returns the correct claimant_pension_benefits' do
+      expect(populated_earnings_and_benefits.agree_with_claimant_pension_benefits).to be false
     end
 
-    it 'with disagree claimant_pension_benefits_reason' do
-      earnings_and_benefits = described_class.new(disagree_claimant_pension_benefits_reason: 'lorem ipsum pension')
-
-      expect(earnings_and_benefits.disagree_claimant_pension_benefits_reason).to eql 'lorem ipsum pension'
+    it 'returns the correct disagree' do
+      expect(populated_earnings_and_benefits.disagree_claimant_pension_benefits_reason).to eql 'lorem ipsum pension'
     end
   end
 
   describe ".to_h " do
-    it "will take two strings and convert them into a hash" do
-      earnings_and_benefits = described_class.new(agree_with_claimants_hours: true)
-
-      expect(earnings_and_benefits.to_h).to be_a(Hash)
+    it "will return a hash" do
+      expect(populated_earnings_and_benefits.to_h).to be_a(Hash)
     end
 
     it 'will return the agree_with_claimants_hours key and value pair' do
-      earnings_and_benefits = described_class.new(agree_with_claimants_hours: true)
-
-      expect(earnings_and_benefits.to_h).to include(agree_with_claimants_hours: true)
+      expect(populated_earnings_and_benefits.to_h).to include(agree_with_claimants_hours: false)
     end
 
     it 'will return the queried_hours key and value pair' do
-      earnings_and_benefits = described_class.new(queried_hours: 32)
-
-      expect(earnings_and_benefits.to_h).to include(queried_hours: 32)
+      expect(populated_earnings_and_benefits.to_h).to include(queried_hours: 20.5)
     end
 
     it 'will return the agree_with_earnings_details key and value pair' do
-      earnings_and_benefits = described_class.new(agree_with_earnings_details: false)
-
-      expect(earnings_and_benefits.to_h).to include(agree_with_earnings_details: false)
+      expect(populated_earnings_and_benefits.to_h).to include(agree_with_earnings_details: false)
     end
 
     it 'will return the queried_pay_before_tax key and value pair' do
-      earnings_and_benefits = described_class.new(queried_pay_before_tax: 1000)
-
-      expect(earnings_and_benefits.to_h).to include(queried_pay_before_tax: 1000)
+      expect(populated_earnings_and_benefits.to_h).to include(queried_pay_before_tax: 900.25)
     end
 
     it 'will return the queried_pay_before_tax_period key and value pair' do
-      earnings_and_benefits = described_class.new(queried_pay_before_tax_period: 'Monthly')
-
-      expect(earnings_and_benefits.to_h).to include(queried_pay_before_tax_period: 'Monthly')
+      expect(populated_earnings_and_benefits.to_h).to include(queried_pay_before_tax_period: 'weekly')
     end
 
     it 'will return the queried_take_home_pay key and value pair' do
-      earnings_and_benefits = described_class.new(queried_take_home_pay: 900)
-
-      expect(earnings_and_benefits.to_h).to include(queried_take_home_pay: 900)
+      expect(populated_earnings_and_benefits.to_h).to include(queried_take_home_pay: 100.5)
     end
 
     it 'will return the queried_take_home_pay_period key and value pair' do
-      earnings_and_benefits = described_class.new(queried_take_home_pay_period: 'Monthly')
-
-      expect(earnings_and_benefits.to_h).to include(queried_take_home_pay_period: 'Monthly')
+      expect(populated_earnings_and_benefits.to_h).to include(queried_take_home_pay_period: 'weekly')
     end
 
     it 'will return the agree_with_claimant_notice key and value pair' do
-      earnings_and_benefits = described_class.new(agree_with_claimant_notice: false)
-
-      expect(earnings_and_benefits.to_h).to include(agree_with_claimant_notice: false)
+      expect(populated_earnings_and_benefits.to_h).to include(agree_with_claimant_notice: false)
     end
 
     it 'will return the disagree_claimant_notice_reason key and value pair' do
-      earnings_and_benefits = described_class.new(disagree_claimant_notice_reason: 'lorem ipsum notice reason')
-
-      expect(earnings_and_benefits.to_h).to include(disagree_claimant_notice_reason: 'lorem ipsum notice reason')
+      expect(populated_earnings_and_benefits.to_h).to include(disagree_claimant_notice_reason: 'lorem ipsum notice')
     end
 
     it 'will return the agree_with_claimant_pension_benefits key and value pair' do
-      earnings_and_benefits = described_class.new(agree_with_claimant_pension_benefits: false)
-
-      expect(earnings_and_benefits.to_h).to include(agree_with_claimant_pension_benefits: false)
+      expect(populated_earnings_and_benefits.to_h).to include(agree_with_claimant_pension_benefits: false)
     end
 
     it 'will return the disagree_claimant_pension_benefits_reason key and value pair' do
-      earnings_and_benefits = described_class.new(disagree_claimant_pension_benefits_reason: 'lorem ipsum claimant pension reason')
-
-      expect(earnings_and_benefits.to_h).to include(disagree_claimant_pension_benefits_reason: 'lorem ipsum claimant pension reason')
+      expect(populated_earnings_and_benefits.to_h).to include(disagree_claimant_pension_benefits_reason: 'lorem ipsum pension')
     end
 
+  end
+
+  context 'when left blank' do
+    it 'will not raise a validation error on agree with claimants hours' do
+      populated_earnings_and_benefits.agree_with_claimants_hours = nil
+
+      expect(populated_earnings_and_benefits).to be_valid
+    end
+
+    it 'will not raise a validation error on queried_hours' do
+      populated_earnings_and_benefits.queried_hours = nil
+
+      expect(populated_earnings_and_benefits).to be_valid
+    end
+
+    it 'will not raise a validation error on agree_with_earnings_details ' do
+      populated_earnings_and_benefits.agree_with_earnings_details = nil
+
+      expect(populated_earnings_and_benefits).to be_valid
+    end
+
+    it 'will not raise a validation error on queried_pay_before_tax' do
+      populated_earnings_and_benefits.queried_pay_before_tax = nil
+
+      expect(populated_earnings_and_benefits).to be_valid
+    end
+
+    it 'will not raise a validation error on queried_pay_before_tax_period' do
+      populated_earnings_and_benefits.queried_pay_before_tax_period = nil
+
+      expect(populated_earnings_and_benefits).to be_valid
+    end
+
+    it 'will not raise a validation error on queried_take_home_pay' do
+      populated_earnings_and_benefits.queried_take_home_pay = nil
+
+      expect(populated_earnings_and_benefits).to be_valid
+    end
+
+    it 'will not raise a validation error on queried_take_home_pay_period' do
+      populated_earnings_and_benefits.queried_take_home_pay_period = nil
+
+      expect(populated_earnings_and_benefits).to be_valid
+    end
+
+    it 'will not raise a validation error on agree_with_claimant_notice' do
+      populated_earnings_and_benefits.agree_with_claimant_notice = nil
+
+      expect(populated_earnings_and_benefits).to be_valid
+    end
+
+    it 'will not raise a validation error on disagree_claimant_notice_reason' do
+      populated_earnings_and_benefits.disagree_claimant_notice_reason = nil
+
+      expect(populated_earnings_and_benefits).to be_valid
+    end
+
+    it 'will not raise a validation error on agree_with_claimant_pension_benefits' do
+      populated_earnings_and_benefits.agree_with_claimant_pension_benefits = nil
+
+      expect(populated_earnings_and_benefits).to be_valid
+    end
+
+    it 'will not raise a validation error on disagree_with_claimant_pension_benefits_reason' do
+      populated_earnings_and_benefits.disagree_claimant_pension_benefits_reason = nil
+
+      expect(populated_earnings_and_benefits).to be_valid
+    end
   end
 end

--- a/test_common/capybara_selectors/embedded_single_choice_option.rb
+++ b/test_common/capybara_selectors/embedded_single_choice_option.rb
@@ -1,6 +1,6 @@
 Capybara.add_selector(:embedded_single_choice_option) do
   xpath do |locator, _options|
     translated = ET3::Test::Messaging.instance.translate(locator)
-    XPath.generate { |x| x.descendant(:div)[x.child(:fieldset)[x.child(:legend)[x.string.n.is(translated)]]] }
+    XPath.generate { |x| x.descendant(:div)[x.child(:div)[x.child(:fieldset)[x.child(:legend)[x.string.n.is(translated)]]]] }
   end
 end

--- a/test_common/fixtures/personas.yml
+++ b/test_common/fixtures/personas.yml
@@ -1,4 +1,5 @@
 company01:
+  # Respondents Details
   case_number: 7654321/2017
   name: dodgy_co
   contact: John Smith
@@ -14,6 +15,7 @@ company01:
   email_address: john@dodgyco.com
   organisation_employ_gb: 100
   organisation_more_than_one_site: 'No'
+  # Claimants Details
   claimants_name: Jane Doe
   agree_with_early_conciliation_details: 'No'
   disagree_conciliation_reason: 'lorem ipsum conciliation'
@@ -24,6 +26,7 @@ company01:
   continued_employment: 'No'
   agree_with_claimants_description_of_job_or_title: 'No'
   disagree_claimants_job_or_title: 'lorem ipsum job title'
+  # Earnings and Benefits Page
   agree_with_claimants_hours: 'No'
   queried_hours: 32
   agree_with_earnings_details: 'No'
@@ -90,3 +93,18 @@ erroneously_entering_data:
   continued_employment: 'No'
   agree_with_claimants_description_of_job_or_title: 'Yes'
   disagree_claimants_job_or_title: null
+  # Earnings and Benefits Page
+  agree_with_claimants_hours: 'No'
+  queried_hours: string
+  agree_with_earnings_details: 'No'
+  queried_pay_before_tax: string
+  queried_pay_before_tax_period: 'Weekly'
+  queried_take_home_pay: string
+  queried_take_home_pay_period: 'Weekly'
+  agree_with_claimant_notice: 'No'
+  disagree_claimant_notice_reason: |
+    Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem. Nulla consequat massa quis enim. Donec pede justo, fringilla vel, aliquet nec, vulputate eget, arcu. In enim justo, rhoncus ut, imperdiet a,
+  agree_with_claimant_pension_benefits: 'No'
+  disagree_claimant_pension_benefits_reason: |
+    Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem. Nulla consequat massa quis enim. Donec pede justo, fringilla vel, aliquet nec, vulputate e
+

--- a/test_common/messaging/en.yml
+++ b/test_common/messaging/en.yml
@@ -90,51 +90,51 @@ en:
         label: Please give the details you believe to be correct (optional)
     # Earnings and Benefits Page
     agree_with_claimants_hours:
-      label: Are the claimant's hours of work correct?
+      label: Are the claimant's hours of work correct? (optional)
       'yes':
         label: 'Yes'
       'no':
         label: 'No'
       queried_hours:
-        label: Please enter the details you believe to be correct
+        label: Please enter the details you believe to be correct (optional)
     agree_with_earnings_details:
-      label: Are the earnings details given by the claimant correct?
+      label: Are the earnings details given by the claimant correct? (optional)
       'yes':
         label: 'Yes'
       'no':
         label: 'No'
       queried_pay_before_tax:
-        label: 'Pay before tax'
+        label: Pay before tax (optional)
       queried_pay_before_tax_period:
-        label: 'Pay before tax period'
+        label: Pay before tax period (optional)
         monthly:
-          label: 'Monthly'
+          label: Monthly
         weekly:
-          label: 'Weekly'
+          label: Weekly
       queried_take_home_pay:
-        label: 'Normal take-home pay'
+        label: Normal take-home pay (optional)
       queried_take_home_pay_period:
-        label: 'Normal take-home pay period'
+        label: Normal take-home pay period (optional)
         monthly:
-          label: 'Monthly'
+          label: Monthly
         weekly:
-          label: 'Weekly'
+          label: Weekly
     agree_with_claimant_notice:
-      label: Is the information given by the claimant correct about being paid for, or working a period of notice?
+      label: Is the information given by the claimant correct about being paid for, or working a period of notice? (optional)
       'yes':
         label: 'Yes'
       'no':
         label: 'No'
       disagree_claimant_notice_reason:
-        label: Please give the details you believe to be correct below. If you didn't give notice or pay them instead of letting them work their notice please explain what happened and why
+        label: Please give the details you believe to be correct below. If you didn't give notice or pay them instead of letting them work their notice please explain what happened and why (optional)
     agree_with_claimant_pension_benefits:
-      label: Are the details about pension and other benefits e.g. company car, medical insurance, etc. given by the claimant correct?
+      label: Are the details about pension and other benefits given by the claimant correct? (optional)
       'yes':
         label: 'Yes'
       'no':
         label: 'No'
       disagree_claimant_pension_benefits_reason:
-        label: Please give the details you believe to be correct.
+        label: Please give the details you believe to be correct. (optional)
     # Response Page
     defend_claim:
       label: Do you defend the claim?*
@@ -251,3 +251,4 @@ en:
       contains_numbers: must not contain numbers
       invalid: is invalid
       not_a_number: is not a number
+      too_long: characters is the maximum allowed

--- a/test_common/page_objects/earnings_and_benefits_page.rb
+++ b/test_common/page_objects/earnings_and_benefits_page.rb
@@ -3,23 +3,29 @@ module ET3
     class EarningsAndBenefitsPage < BasePage
       set_url '/respond/earnings_and_benefits'
 
-      section :agree_with_claimants_hours_question, :single_choice_option, 'questions.agree_with_claimants_hours.label', exact: true do
+      element :error_header, :error_titled, 'errors.header', exact: true
 
-        section :yes, :gds_multiple_choice_option, 'questions.agree_with_claimants_hours.yes.label', exact: true do
+      section :agree_with_claimants_hours_question, :single_choice_option, 'questions.agree_with_claimants_hours.label', exact: false do
+
+        section :yes, :gds_multiple_choice_option, 'questions.agree_with_claimants_hours.yes.label', exact: false do
           element :selector, :css, 'input'
 
           delegate :set, to: :selector
         end
 
-        section :no, :gds_multiple_choice_option, 'questions.agree_with_claimants_hours.no.label', exact: true do
+        section :no, :gds_multiple_choice_option, 'questions.agree_with_claimants_hours.no.label', exact: false do
           element :selector, :css, 'input'
 
           delegate :set, to: :selector
         end
 
-        section :queried_hours, :inputtext_labelled, 'questions.agree_with_claimants_hours.queried_hours.label', exact: true do
-          delegate :set, to: :root_element
+        section :queried_hours, :question_labelled, 'questions.agree_with_claimants_hours.queried_hours.label', exact: false do
+          element :field, :css, 'input'
+
+          delegate :set, to: :field
         end
+
+        element :error_not_a_number, :exact_error_text, 'errors.messages.not_a_number', exact: false
 
         def set_for(user_persona)
           if user_persona.agree_with_claimants_hours == 'No'
@@ -31,23 +37,23 @@ module ET3
         end
       end
 
-      section :agree_with_earnings_details_question, :single_choice_option, 'questions.agree_with_earnings_details.label', exact: true do
+      section :agree_with_earnings_details_question, :single_choice_option, 'questions.agree_with_earnings_details.label', exact: false do
 
-        section :yes, :gds_multiple_choice_option, 'questions.agree_with_earnings_details.yes.label', exact: true do
+        section :yes, :gds_multiple_choice_option, 'questions.agree_with_earnings_details.yes.label', exact: false do
           element :selector, :css, 'input'
 
           delegate :set, to: :selector
         end
 
-        section :no, :gds_multiple_choice_option, 'questions.agree_with_earnings_details.no.label', exact: true do
+        section :no, :gds_multiple_choice_option, 'questions.agree_with_earnings_details.no.label', exact: false do
           element :selector, :css, 'input'
 
           delegate :set, to: :selector
         end
 
-        section :queried_pay_before_tax, :embedded_single_choice_option, 'questions.agree_with_earnings_details.queried_pay_before_tax.label', exact: true do
+        section :queried_pay_before_tax, :embedded_single_choice_option, 'questions.agree_with_earnings_details.queried_pay_before_tax_period.label', exact: true do
           
-          section :field, :inputtext_labelled, 'questions.agree_with_earnings_details.queried_pay_before_tax.label', exact: true do
+          section :field, :inputtext_labelled, 'questions.agree_with_earnings_details.queried_pay_before_tax.label', exact: false do
             delegate :set, to: :root_element
           end
 
@@ -67,9 +73,9 @@ module ET3
 
         end
 
-        section :queried_take_home_pay, :embedded_single_choice_option, 'questions.agree_with_earnings_details.queried_take_home_pay.label', exact: true do
+        section :queried_take_home_pay, :embedded_single_choice_option, 'questions.agree_with_earnings_details.queried_take_home_pay_period.label', exact: false do
 
-          section :field, :inputtext_labelled, 'questions.agree_with_earnings_details.queried_take_home_pay.label', exact: true do
+          section :field, :inputtext_labelled, 'questions.agree_with_earnings_details.queried_take_home_pay.label', exact: false do
             delegate :set, to: :root_element
           end
           
@@ -87,6 +93,8 @@ module ET3
 
           delegate :set, to: :field
         end
+        
+        element :error_not_a_number, :exact_error_text, 'errors.messages.not_a_number', exact: false
 
         def set_for(user_persona)
           if user_persona.agree_with_earnings_details == 'No'
@@ -109,7 +117,7 @@ module ET3
         end
       end
 
-      section :agree_with_claimant_notice_question, :single_choice_option, 'questions.agree_with_claimant_notice.label', exact: true do
+      section :agree_with_claimant_notice_question, :single_choice_option, 'questions.agree_with_claimant_notice.label', exact: false do
 
         section :yes, :gds_multiple_choice_option, 'questions.agree_with_claimant_notice.yes.label', exact: true do
           element :selector, :css, 'input'
@@ -123,9 +131,11 @@ module ET3
           delegate :set, to: :selector
         end
 
-        section :disagree_claimant_notice_reason, :textarea_labelled, 'questions.agree_with_claimant_notice.disagree_claimant_notice_reason.label', exact: true do
+        section :disagree_claimant_notice_reason, :textarea_labelled, 'questions.agree_with_claimant_notice.disagree_claimant_notice_reason.label', exact: false do
           delegate :set, to: :root_element
         end
+
+        element :error_too_long, :exact_error_text, 'errors.messages.too_long', exact: false
 
         def set_for(user_persona)
           if user_persona.agree_with_claimant_notice == 'No'
@@ -137,7 +147,7 @@ module ET3
         end
       end
 
-      section :agree_with_claimant_pension_benefits_question, :single_choice_option, 'questions.agree_with_claimant_pension_benefits.label', exact: true do
+      section :agree_with_claimant_pension_benefits_question, :single_choice_option, 'questions.agree_with_claimant_pension_benefits.label', exact: false do
         
         section :yes, :gds_multiple_choice_option, 'questions.agree_with_claimant_pension_benefits.yes.label', exact: true do
           element :selector, :css, 'input'
@@ -151,9 +161,11 @@ module ET3
           delegate :set, to: :selector
         end
 
-        section :disagree_claimant_pension_benefits_reason, :textarea_labelled, 'questions.agree_with_claimant_pension_benefits.disagree_claimant_pension_benefits_reason.label', exact: true do
+        section :disagree_claimant_pension_benefits_reason, :textarea_labelled, 'questions.agree_with_claimant_pension_benefits.disagree_claimant_pension_benefits_reason.label', exact: false do
           delegate :set, to: :root_element
         end
+
+        element :error_too_long, :exact_error_text, 'errors.messages.too_long', exact: false
 
         def set_for(user_persona)
           if user_persona.agree_with_claimant_pension_benefits == 'No'


### PR DESCRIPTION
As before, this won't look 100% correct until the govuk form builder gem is updated

Otherwise please ensure the validation logic looks correct. The page should render much better than it did before, with the implementation of GDS hints.