### PR TITLE
Enable tests to run while dev server is running

### DIFF
--- a/test_common/capybara/capybara_driver_helper.rb
+++ b/test_common/capybara/capybara_driver_helper.rb
@@ -47,4 +47,4 @@ end
 Capybara.always_include_port = true
 Capybara.app_host = ENV.fetch('CAPYBARA_APP_HOST', "http://#{ENV.fetch('HOSTNAME', 'localhost')}")
 Capybara.server_host = ENV.fetch('CAPYBARA_SERVER_HOST', ENV.fetch('HOSTNAME', 'localhost'))
-Capybara.server_port = ENV.fetch('CAPYBARA_SERVER_PORT', '3000') unless ENV['CAPYBARA_SERVER_PORT'] == 'random'
+Capybara.server_port = ENV.fetch('CAPYBARA_SERVER_PORT') if ENV.key?('CAPYBARA_SERVER_PORT')


### PR DESCRIPTION
One-line change to prevent the capybara port being forced