### PR TITLE
Mark all optional questions

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -35,7 +35,7 @@ en:
     fieldset:
       respondents_detail:
         contact_preference: How would you prefer us to contact you? (optional)
-        organisation_more_than_one_site: Does this organisation have more than one site in Great Britain? (optional)
+        organisation_more_than_one_site: Does this organisation have more than one site in Great Britain?
       claimants_detail:
         agree_with_early_conciliation_details: Do you agree with the details given by the claimant about Early Conciliation with Acas? (optional)
         agree_with_employment_dates: Are the dates of employment given by the claimant correct?

--- a/test_common/messaging/en.yml
+++ b/test_common/messaging/en.yml
@@ -36,7 +36,7 @@ en:
     organisation_employ_gb:
       label: How many people does this organisation employ in Great Britain? (optional)
     organisation_more_than_one_site:
-      label: Does this organisation have more than one site in Great Britain? (optional)
+      label: Does this organisation have more than one site in Great Britain?
       'yes':
         label: 'Yes'
       'no':


### PR DESCRIPTION
All questions are now appropriately marked optional where appropriate. Mandatory questions are not marked. This is in line with GDS spec.