### PR TITLE
Show "blank" as the error when fields are left blank

### DIFF
--- a/app/forms/your_representatives_details.rb
+++ b/app/forms/your_representatives_details.rb
@@ -52,7 +52,12 @@ class YourRepresentativesDetails < BaseForm
         "Other"
       ]
     }
-  validates :representative_name, persons_name: true
+  validates :representative_name,
+    presence: true,
+    if: proc { |c| c.representative_name.blank? }
+  validates :representative_name,
+    persons_name: true,
+    unless: proc { |c| c.representative_name.blank? }
   validates :representative_building,
     :representative_street,
     :representative_town,

--- a/app/validators/postcode_validator.rb
+++ b/app/validators/postcode_validator.rb
@@ -7,7 +7,7 @@ class PostcodeValidator < ActiveModel::EachValidator
   end
 
   def validate_each(record, attribute, value)
-    if value.nil?
+    if value.blank?
       record.errors.add(attribute, :blank)
     else
       postcode = postcode_service.parse(value)

--- a/spec/forms/your_representatives_details_spec.rb
+++ b/spec/forms/your_representatives_details_spec.rb
@@ -239,7 +239,7 @@ RSpec.describe YourRepresentativesDetails, type: :model do
 
       populated_your_representatives_details.valid?
 
-      expect(populated_your_representatives_details.errors.details[:representative_name]).to include a_hash_including(error: :invalid)
+      expect(populated_your_representatives_details.errors.details[:representative_name]).to include a_hash_including(error: :blank)
     end
 
     it 'will raise a validation error on representative_building' do


### PR DESCRIPTION
As highlighted by @AlexaVB on RST-889, error messages now state that the field has been left blank.