### PR TITLE
RST-1045 Fix error summary links

### DIFF
--- a/app/views/claimants_details/edit.html.slim
+++ b/app/views/claimants_details/edit.html.slim
@@ -4,9 +4,10 @@
 
   = form_for @claimants_detail, url: claimants_details_path, method: :patch  do |f|
 
-    = GovukElementsErrorsHelper.error_summary @claimants_detail,
-    "Please review the following",
-    "Optional description of the errors and how to correct them"
+    div data-turbolinks="false"
+      = GovukElementsErrorsHelper.error_summary @claimants_detail,
+        "Please review the following",
+        "Clicking on an error will navigate you directly to the question. Please correct these errors before continuing."
 
     = f.text_field :claimants_name
     = f.radio_button_fieldset :agree_with_early_conciliation_details do |b|

--- a/app/views/confirmation_of_supplied_details/edit.html.slim
+++ b/app/views/confirmation_of_supplied_details/edit.html.slim
@@ -7,9 +7,10 @@
 
   = form_for @confirmation_of_supplied_details, url: confirmation_of_supplied_details_path, method: :patch  do |f|
 
-    = GovukElementsErrorsHelper.error_summary @confirmation_of_supplied_details,
-    "Please review the following",
-    "Optional description of the errors and how to correct them" 
+    div data-turbolinks="false"
+      = GovukElementsErrorsHelper.error_summary @confirmation_of_supplied_details,
+        "Please review the following",
+        "Clicking on an error will navigate you directly to the question. Please correct these errors before continuing."
 
     = f.text_field :email_receipt
     = f.text_field :email_receipt_confirmation

--- a/app/views/earnings_and_benefits/edit.html.slim
+++ b/app/views/earnings_and_benefits/edit.html.slim
@@ -4,9 +4,10 @@
 
   = form_for @earnings_and_benefits, url: earnings_and_benefits_path, method: :patch  do |f|
 
-    = GovukElementsErrorsHelper.error_summary @earnings_and_benefits,
-    "Please review the following",
-    "Optional description of the errors and how to correct them"
+    div data-turbolinks="false"
+      = GovukElementsErrorsHelper.error_summary @earnings_and_benefits,
+        "Please review the following",
+        "Clicking on an error will navigate you directly to the question. Please correct these errors before continuing."
 
     = f.radio_button_fieldset :agree_with_claimants_hours do |b|
       = content_tag :div, {class: 'multiple-choice'} do

--- a/app/views/employers_contract_claims/edit.html.slim
+++ b/app/views/employers_contract_claims/edit.html.slim
@@ -6,9 +6,10 @@
 
   = form_for @employers_contract_claim, url: employers_contract_claim_path, method: :patch  do |f|
 
-    = GovukElementsErrorsHelper.error_summary @employers_contract_claim,
-    "Please review the following",
-    "Optional description of the errors and how to correct them"
+    div data-turbolinks="false"
+      = GovukElementsErrorsHelper.error_summary @employers_contract_claim,
+        "Please review the following",
+        "Clicking on an error will navigate you directly to the question. Please correct these errors before continuing."
 
     = f.radio_button_fieldset :make_employer_contract_claim do |b|
       = content_tag :div, {class: 'multiple-choice'} do

--- a/app/views/respondents_details/edit.html.slim
+++ b/app/views/respondents_details/edit.html.slim
@@ -4,9 +4,10 @@
 
   = form_for @respondents_detail, url: respondents_details_path, method: :patch  do |f|
 
-    = GovukElementsErrorsHelper.error_summary @respondents_detail,
-      "Please review the following",
-      "Optional description of the errors and how to correct them"
+    div data-turbolinks="false"
+      = GovukElementsErrorsHelper.error_summary @respondents_detail,
+        "Please review the following",
+        "Clicking on an error will navigate you directly to the question. Please correct these errors before continuing."
 
     = f.text_field :case_number
     = f.text_field :name

--- a/app/views/responses/edit.html.slim
+++ b/app/views/responses/edit.html.slim
@@ -4,9 +4,10 @@
 
   = form_for @response, url: response_path, method: :patch  do |f|
 
-    = GovukElementsErrorsHelper.error_summary @response,
-    "Please review the following",
-    "Optional description of the errors and how to correct them"
+    div data-turbolinks="false"
+      = GovukElementsErrorsHelper.error_summary @response,
+        "Please review the following",
+        "Clicking on an error will navigate you directly to the question. Please correct these errors before continuing."
 
     = f.radio_button_fieldset :defend_claim do |b|
       = content_tag :div, {class: 'multiple-choice', data: { target: :defend_claim_facts }} do

--- a/app/views/your_representatives/edit.html.slim
+++ b/app/views/your_representatives/edit.html.slim
@@ -4,10 +4,6 @@
 
   = form_for @your_representative, url: your_representative_path, method: :patch  do |f|
 
-    = GovukElementsErrorsHelper.error_summary @response,
-    "Please review the following",
-    "Optional description of the errors and how to correct them"    
-
     = f.radio_button_fieldset :have_representative do |b|
       = content_tag :div, {class: 'multiple-choice'} do
         = b.radio_button(:have_representative, true) + label(:defend_claim_true, t('helpers.label.response.defend_claim.choices.yes'), value: :yes)

--- a/app/views/your_representatives_details/edit.html.slim
+++ b/app/views/your_representatives_details/edit.html.slim
@@ -6,9 +6,10 @@
 
   = form_for @your_representatives_details, url: your_representatives_details_path, method: :patch  do |f|
 
-    = GovukElementsErrorsHelper.error_summary @your_representatives_details,
-    "Please review the following",
-    "Optional description of the errors and how to correct them"
+    div data-turbolinks="false"
+      = GovukElementsErrorsHelper.error_summary @your_representatives_details,
+        "Please review the following",
+        "Clicking on an error will navigate you directly to the question. Please correct these errors before continuing."
 
     = f.radio_button_fieldset :type_of_representative do |b|
       = content_tag :div, {class: 'multiple-choice'} do


### PR DESCRIPTION
This change places the error summary in a div that disables turbolinks, fixing a bug that causes the page to reload.