### PR TITLE
RST-882 Fix strings on CoSD page

### DIFF
--- a/app/views/confirmation_of_supplied_details/edit.html.slim
+++ b/app/views/confirmation_of_supplied_details/edit.html.slim
@@ -13,6 +13,9 @@
 
     = f.text_field :email_receipt
     = f.text_field :email_receipt_confirmation
+
+    p Pressing "Submit Form" below will send the details confirmed below for processing.
+
     = f.submit("Submit Form", class: 'button')
 
   h2.heading-medium Confirmation of Supplied Details

--- a/app/views/confirmation_of_supplied_details/edit.html.slim
+++ b/app/views/confirmation_of_supplied_details/edit.html.slim
@@ -79,7 +79,7 @@
         td = @hash_store[:respondents_detail_answers][:employment_at_site_number]
       tr
         td
-          = link_to("Edit Answers on this Page", edit_respondents_details_path, class: 'button')
+          = link_to("Edit answers on this page", edit_respondents_details_path, class: 'button')
         td
           a href="#content" Back to the top
   table
@@ -121,7 +121,7 @@
         td = @hash_store[:claimants_detail_answers][:disagree_claimants_job_or_title]
       tr
         td
-          = link_to("Edit Answers on this Page", edit_claimants_details_path, class: 'button')
+          = link_to("Edit answers on this page", edit_claimants_details_path, class: 'button')
         td
           a href="#content" Back to the top
   table
@@ -166,7 +166,7 @@
         td = @hash_store[:earnings_and_benefits_answers][:disagree_claimant_pension_benefits_reason]
       tr
         td
-          = link_to("Edit Answers on this Page", edit_earnings_and_benefits_path, class: 'button')
+          = link_to("Edit answers on this page", edit_earnings_and_benefits_path, class: 'button')
         td
           a href="#content" Back to the top
   table
@@ -184,7 +184,7 @@
         td = @hash_store[:response_answers][:defend_claim_facts]
       tr
         td
-          = link_to("Edit Answers on this Page", edit_response_path, class: 'button')
+          = link_to("Edit answers on this page", edit_response_path, class: 'button')
         td
           a href="#content" Back to the top
   table
@@ -199,7 +199,7 @@
         td = @hash_store[:your_representative_answers][:have_representative]
       tr
         td
-          = link_to("Edit Answers on this Page", edit_your_representative_path, class: 'button')
+          = link_to("Edit answers on this page", edit_your_representative_path, class: 'button')
         td
           a href="#content" Back to the top
   table
@@ -261,7 +261,7 @@
         td = @hash_store[:your_representatives_details_answers][:representative_disability_information]
       tr
         td
-          = link_to("Edit Answers on this Page", edit_your_representatives_details_path, class: 'button')
+          = link_to("Edit answers on this page", edit_your_representatives_details_path, class: 'button')
         td
           a href="#content" Back to the top
   table
@@ -278,6 +278,6 @@
         td = @hash_store[:employer_contract_claim_answers][:claim_information]
       tr
         td
-          = link_to("Edit Answers on this Page", edit_employers_contract_claim_path, class: 'button')
+          = link_to("Edit answers on this page", edit_employers_contract_claim_path, class: 'button')
         td
           a href="#content" Back to the top

--- a/app/views/confirmation_of_supplied_details/edit.html.slim
+++ b/app/views/confirmation_of_supplied_details/edit.html.slim
@@ -3,7 +3,7 @@
 .content-body.confirmation-of-supplied-details
 
   h2.heading-medium Email Receipt
-  p Please enter your email address so that we can provided you with a receipt of your transaction.
+  p Please enter your email address so that we can provide you with a receipt of your transaction.
 
   = form_for @confirmation_of_supplied_details, url: confirmation_of_supplied_details_path, method: :patch  do |f|
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -224,7 +224,7 @@ en:
           use our upload facility at the end of this form where you will be able to upload a Rich Text Format (.rtf) file.
           If you exceed 50 lines you will not receive full details of your claim in the PDF returned to you on submission of the form.
       confirmation_of_supplied_details:
-        email_receipt: Please enter your email address so that we can provided you with a receipt of your transaction
+        email_receipt: Please enter your email address so that we can provide you with a receipt of your transaction
         email_receipt_confirmation: This field is mandatory if you would like an email receipt
   errors:
     messages:


### PR DESCRIPTION
* Remove camel-casing on "Edit page" buttons.
* Fix typo ("we can provided you" -> "we can provide you")
* Re-introduce line explaining form submission

All the above as per comments left on RST-882