### PR TITLE
RST-1155 Update hint string on employment dates

### DIFF
--- a/app/views/claimants_details/edit.html.slim
+++ b/app/views/claimants_details/edit.html.slim
@@ -24,9 +24,9 @@
         = b.radio_button(:agree_with_employment_dates, false) + label(:agree_with_employment_dates_false, t('helpers.label.claimants_detail.agree_with_employment_dates.choices.no'), value: :no)
       #disagree_employment_dates.panel.panel-border-narrow.js-hidden
         .form-group
-          = f.gov_uk_date_field :employment_start, legend_text: t('helpers.label.claimants_detail.employment_start')
+          = f.gov_uk_date_field :employment_start, legend_text: t('helpers.label.claimants_detail.employment_start'), form_hint_text: t('helpers.hint.claimants_detail.employment_dates')
         .form-group
-          = f.gov_uk_date_field :employment_end, legend_text: t('helpers.label.claimants_detail.employment_end')
+          = f.gov_uk_date_field :employment_end, legend_text: t('helpers.label.claimants_detail.employment_end'), form_hint_text: t('helpers.hint.claimants_detail.employment_dates')
         .form-group
           = f.text_area :disagree_employment
     = f.radio_button_fieldset :continued_employment do |b|

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -195,6 +195,8 @@ en:
     hint:
       respondents_detail:
         mobile_number: If different to your primary contact number
+      claimants_detail:
+        employment_dates: For example, 31 03 1980
       earnings_and_benefits:
         queried_hours: In hours per week
         agree_with_earnings_details: If No, please give the details you believe to be correct


### PR DESCRIPTION
Small change on `claimants_detail` page that changes the employment date hint text from "For example, 31 3 1980" to "For example, 31 **0**3 1980"