### PR TITLE
RST-1258 Add upload button back after file is successfully uploaded

### DIFF
--- a/app/assets/javascripts/uploadAdditionalInformation.js
+++ b/app/assets/javascripts/uploadAdditionalInformation.js
@@ -51,10 +51,15 @@ $(document).ready(function(){
         */
     }
 
-    function removeButtonElement() {
-        $("button.button.button-secondary").remove();
+    function removeButtonElement(button) {
+        return button.detach();
     }
 
+    function appendButtonElement(button) {
+        $(".dz-default.dz-message.grid-row .column-one-half").append(button);
+    }
+
+    var removedButton;
 
     let uploadAdditionalInfoDropzone = new Dropzone("#upload-additional-file",
         {
@@ -69,7 +74,7 @@ $(document).ready(function(){
                 getPresignedS3Url(function(presignedData) {
                     prepareAwsHiddenInputs(presignedData);
                     setUploadUrl(presignedData.url);
-                    removeButtonElement();
+                    removedButton = removeButtonElement($("#upload-button"));
                     done();
                 });
             },
@@ -78,6 +83,7 @@ $(document).ready(function(){
             // Add a link to remove files that were erroneously uploaded
             addRemoveLinks: true,
             success: function(file, response){
+                appendButtonElement(removedButton);
                 // Take upload URL and pass it into the second form
                 $("#additional_information_upload_additional_information").val($.parseXML(response).getElementsByTagName("Key")[0].childNodes[0].nodeValue);
                 $("#additional_information_upload_file_name").val(file.name);
@@ -89,9 +95,5 @@ $(document).ready(function(){
         // TODO: RST-1220 - Error Handling:
         // Build a proper warning system for "too many files" warning.
         alert("too many files");
-    });
-
-    uploadAdditionalInfoDropzone.on("sending", function(file, xhr, formData) {
-        // Perhaps rebuild form without using hidden elements here?
     });
 });

--- a/app/views/additional_informations/edit.html.slim
+++ b/app/views/additional_informations/edit.html.slim
@@ -12,7 +12,7 @@
       .column-one-half
         span.normal= "Drag and drop files here"
         .bold-normal= "or"
-        button.button.button-secondary type="button" = t('helpers.label.additional_information.upload_button')
+        button.button.button-secondary#upload-button type="button" = t('helpers.label.additional_information.upload_button')
 
     = hidden_field :aws, :key
     = hidden_field :aws, :policy


### PR DESCRIPTION
RST-1247 was a hotfix that removed the upload button from the submission data by removing it permanently from the page.

This change sees it temporarily removed, form submitted and added once again.