### PR TITLE
Feature/RST-1127 - Update error handling and strings

### DIFF
--- a/app/forms/claimants_detail.rb
+++ b/app/forms/claimants_detail.rb
@@ -38,7 +38,7 @@ class ClaimantsDetail < BaseForm
   private
 
   def disagree_with_employment_dates?
-    !agree_with_employment_dates
+    agree_with_employment_dates == false
   end
 
 end

--- a/app/validators/email_address_validator.rb
+++ b/app/validators/email_address_validator.rb
@@ -1,6 +1,6 @@
 class EmailAddressValidator < ActiveModel::EachValidator
   EMAIL_REGEX = /\A([^@\s]+)@((?:[-a-z0-9]+\.)+[a-z]{2,})\z/i
   def validate_each(record, attribute, value)
-    record.errors.add(attribute, :invalid) unless value =~ EMAIL_REGEX
+    record.errors.add(attribute, :invalid_email) unless value =~ EMAIL_REGEX
   end
 end

--- a/app/validators/persons_name_validator.rb
+++ b/app/validators/persons_name_validator.rb
@@ -1,10 +1,6 @@
 class PersonsNameValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
-    if value =~ /\d/
-      record.errors.add(attribute, :contains_numbers)
-    elsif value !~ /\ /
-      record.errors.add(attribute, :contains_no_spaces)
-    end
-    record.errors.add(attribute, :invalid) unless value =~ /\A([a-zA-Z\ \.\'\-])+\ ([a-zA-Z\ \.\'\-])+\z/
+    return record.errors.add(attribute, :contains_numbers) if value =~ /\d/
+    record.errors.add(attribute, :invalid_name) unless value =~ /\A([a-zA-Z\ \.\'\-])+\ ([a-zA-Z\ \.\'\-])+\z/
   end
 end

--- a/app/validators/phone_number_validator.rb
+++ b/app/validators/phone_number_validator.rb
@@ -1,5 +1,5 @@
 class PhoneNumberValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
-    record.errors.add(attribute, :invalid) unless value =~ /\A(\+?)((\d(\ ?)(\-?)){7,})\z/
+    record.errors.add(attribute, :invalid_phone_number) unless value =~ /\A(\+?)((\d(\ ?)(\-?)){7,})\z/
   end
 end

--- a/app/validators/postcode_validator.rb
+++ b/app/validators/postcode_validator.rb
@@ -11,7 +11,7 @@ class PostcodeValidator < ActiveModel::EachValidator
       record.errors.add(attribute, :blank)
     else
       postcode = postcode_service.parse(value)
-      record.errors.add(attribute, :invalid) unless postcode.full_valid?
+      record.errors.add(attribute, :invalid_postcode) unless postcode.full_valid?
     end
   end
 

--- a/app/views/claimants_details/edit.html.slim
+++ b/app/views/claimants_details/edit.html.slim
@@ -24,9 +24,9 @@
         = b.radio_button(:agree_with_employment_dates, false) + label(:agree_with_employment_dates_false, t('helpers.label.claimants_detail.agree_with_employment_dates.choices.no'), value: :no)
       #disagree_employment_dates.panel.panel-border-narrow.js-hidden
         .form-group
-          = f.gov_uk_date_field :employment_start, legend_text: t('helpers.label.claimants_detail.employment_start'), form_hint_text: t('helpers.hint.claimants_detail.employment_dates')
+          = f.gov_uk_date_field :employment_start, legend_text: t('helpers.label.claimants_detail.employment_start'), form_hint_text: t('helpers.hint.claimants_detail.employment_start')
         .form-group
-          = f.gov_uk_date_field :employment_end, legend_text: t('helpers.label.claimants_detail.employment_end'), form_hint_text: t('helpers.hint.claimants_detail.employment_dates')
+          = f.gov_uk_date_field :employment_end, legend_text: t('helpers.label.claimants_detail.employment_end'), form_hint_text: t('helpers.hint.claimants_detail.employment_end')
         .form-group
           = f.text_area :disagree_employment
     = f.radio_button_fieldset :continued_employment do |b|

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -205,10 +205,10 @@ en:
         employment_start: For example, 31 03 2010
         employment_end: For example, 01 12 2017
       earnings_and_benefits:
-        queried_hours: In hours per week
+        queried_hours: In hours per week. For example, 39
         agree_with_earnings_details: If No, please give the details you believe to be correct
-        queried_pay_before_tax: Including overtime, commission, bonuses, etc.
-        queried_take_home_pay: Including overtime, commission, bonuses, etc.
+        queried_pay_before_tax: Including overtime, commission, bonuses, etc. For example, 28000
+        queried_take_home_pay: Including overtime, commission, bonuses, etc. For example, 20000
         disagree_claimant_notice_reason: |
           PLEASE NOTE – You will only be able to enter a limited amount of information here (up to 400 characters) if you would like to include more please
           use our upload facility at the end of this form where you will be able to upload a Rich Text Format (.rtf) file.
@@ -247,6 +247,7 @@ en:
       invalid_postcode: This is not a valid UK postcode
       invalid_phone_number: This is not a valid phone number
       inclusion: Please select an option
+      not_a_number: "%{attribute} is not a number"
     attributes:
       contact:
         contains_numbers: Name of contact must not contain numbers
@@ -256,6 +257,12 @@ en:
         not_a_number: Please enter how many people the organisation employs in Great Britain as a number
       claimants_name:
         contains_numbers: Claimant's name must not contain numbers
+      queried_hours:
+        not_a_number: Please enter the number of hours you believe to be correct as a number
+      queried_pay_before_tax:
+        not_a_number: Please enter the pay before tax as a number
+      queried_take_home_pay:
+        not_a_number: Please enter the normal take-home pay as a number
   components:
     single_choice_option_section:
       'yes': "Yes"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -99,7 +99,7 @@ en:
         employment_end: When their employment ended or will end
         disagree_employment: Why do you disagree with the dates given by the claimant
         continued_employment:
-          choices:              
+          choices:
             'yes': 'Yes'
             'no': 'No'
         agree_with_claimants_description_of_job_or_title:
@@ -197,7 +197,10 @@ en:
         email_receipt: Email Address (optional)
     hint:
       respondents_detail:
+        contact: For example, John Smith
         mobile_number: If different to your primary contact number
+        employment_at_site_number: For example, 10
+        organisation_employ_gb: For example, 10
       claimants_detail:
         employment_dates: For example, 31 03 1980
       earnings_and_benefits:
@@ -232,9 +235,24 @@ en:
       confirmation_of_supplied_details:
         email_receipt: For example name@address.com
   errors:
+    format: "%{message}"
     messages:
-      contains_no_spaces: must contain spaces
-      contains_numbers: must not contain numbers
+      contains_no_spaces: "%{attribute} must contain spaces"
+      contains_numbers: "%{attribute} must not contain numbers"
+      blank: "%{attribute} can't be blank"
+      invalid: "%{attribute} is invalid"
+      invalid_email: This is not a valid email address
+      invalid_name: Please enter your full name
+      invalid_postcode: This is not a valid UK postcode
+      invalid_phone_number: This is not a valid phone number
+      inclusion: Please select an option
+    attributes:
+      contact:
+        contains_numbers: Name of contact must not contain numbers
+      employment_at_site_number:
+        not_a_number: Please enter how many people are employed at the place where the claimant worked as a number
+      organisation_employ_gb:
+        not_a_number: Please enter how many people the organisation employs in Great Britain as a number
   components:
     single_choice_option_section:
       'yes': "Yes"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -202,7 +202,8 @@ en:
         employment_at_site_number: For example, 10
         organisation_employ_gb: For example, 10
       claimants_detail:
-        employment_dates: For example, 31 03 1980
+        employment_start: For example, 31 03 2010
+        employment_end: For example, 01 12 2017
       earnings_and_benefits:
         queried_hours: In hours per week
         agree_with_earnings_details: If No, please give the details you believe to be correct
@@ -253,6 +254,8 @@ en:
         not_a_number: Please enter how many people are employed at the place where the claimant worked as a number
       organisation_employ_gb:
         not_a_number: Please enter how many people the organisation employs in Great Britain as a number
+      claimants_name:
+        contains_numbers: Claimant's name must not contain numbers
   components:
     single_choice_option_section:
       'yes': "Yes"

--- a/spec/features/fill_in_confirmation_of_supplied_details_page_spec.rb
+++ b/spec/features/fill_in_confirmation_of_supplied_details_page_spec.rb
@@ -23,6 +23,6 @@ RSpec.feature "Fill in Confirmation of Supplied Details Page", js: true do
     confirmation_of_supplied_details_page.submit_form
 
     expect(confirmation_of_supplied_details_page).to have_error_header
-    expect(confirmation_of_supplied_details_page.email_receipt_question).to have_error_invalid
+    expect(confirmation_of_supplied_details_page.email_receipt_question).to have_error_invalid_email
   end
 end

--- a/spec/features/fill_in_earnings_and_benefits_page_spec.rb
+++ b/spec/features/fill_in_earnings_and_benefits_page_spec.rb
@@ -31,8 +31,8 @@ RSpec.feature "Fill in Earnings and Benefits Page", js: true do
 
     expect(earnings_and_benefits_page).to have_error_header
     expect(earnings_and_benefits_page.agree_with_claimants_hours_question).to have_error_not_a_number
-    expect(earnings_and_benefits_page.agree_with_earnings_details_question).to have_error_not_a_number
-    expect(earnings_and_benefits_page.agree_with_earnings_details_question).to have_error_not_a_number
+    expect(earnings_and_benefits_page.agree_with_earnings_details_question.queried_pay_before_tax).to have_error_not_a_number
+    expect(earnings_and_benefits_page.agree_with_earnings_details_question.queried_take_home_pay).to have_error_not_a_number
     expect(earnings_and_benefits_page.agree_with_claimant_notice_question).to have_error_too_long
     expect(earnings_and_benefits_page.agree_with_claimant_pension_benefits_question).to have_error_too_long
   end

--- a/spec/features/fill_in_respondents_details_page_spec.rb
+++ b/spec/features/fill_in_respondents_details_page_spec.rb
@@ -51,7 +51,7 @@ RSpec.feature "Fill in Respondents Details Page", js: true do
     expect(respondents_details_page.building_name_question).to have_error_blank
     expect(respondents_details_page.street_question).to have_error_blank
     expect(respondents_details_page.town_question).to have_error_blank
-    expect(respondents_details_page.postcode_question).to have_error_invalid
+    expect(respondents_details_page.postcode_question).to have_error_invalid_postcode
     expect(respondents_details_page.contact_preference_question).to have_error_invalid_fax
     expect(respondents_details_page.organisation_employ_gb_question).to have_error_not_a_number
     expect(respondents_details_page.organisation_more_than_one_site_question).to have_error_not_a_number

--- a/spec/features/fill_in_your_representatives_details_page_spec.rb
+++ b/spec/features/fill_in_your_representatives_details_page_spec.rb
@@ -55,10 +55,10 @@ RSpec.feature "Fill in Your Representatives Details Page", js: true do
     expect(your_representatives_details_page.representative_building_question).to have_error_blank
     expect(your_representatives_details_page.representative_street_question).to have_error_blank
     expect(your_representatives_details_page.representative_town_question).to have_error_blank
-    expect(your_representatives_details_page.representative_postcode_question).to have_error_invalid
-    expect(your_representatives_details_page.representative_phone_question).to have_error_invalid
-    expect(your_representatives_details_page.representative_mobile_question).to have_error_invalid
-    expect(your_representatives_details_page.representative_contact_preference_question).to have_error_invalid
+    expect(your_representatives_details_page.representative_postcode_question).to have_error_invalid_postcode
+    expect(your_representatives_details_page.representative_phone_question).to have_error_invalid_phone_number
+    expect(your_representatives_details_page.representative_mobile_question).to have_error_invalid_phone_number
+    expect(your_representatives_details_page.representative_contact_preference_question).to have_error_invalid_email
     expect(your_representatives_details_page.representative_disability_question).to have_error_too_long
   end
 

--- a/spec/forms/respondents_detail_spec.rb
+++ b/spec/forms/respondents_detail_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe RespondentsDetail, type: :model do
 
       populated_respondent_detail.valid?
 
-      expect(populated_respondent_detail.errors.details[:email_address]).to include a_hash_including(error: :invalid)
+      expect(populated_respondent_detail.errors.details[:email_address]).to include a_hash_including(error: :invalid_email)
     end
 
     it 'will not validate a name with numbers in' do
@@ -44,7 +44,7 @@ RSpec.describe RespondentsDetail, type: :model do
 
       populated_respondent_detail.valid?
 
-      expect(populated_respondent_detail.errors.details[:fax_number]).to include a_hash_including(error: :invalid)
+      expect(populated_respondent_detail.errors.details[:fax_number]).to include a_hash_including(error: :invalid_phone_number)
     end
 
     it 'will not validate a contact_number with letters' do
@@ -52,7 +52,7 @@ RSpec.describe RespondentsDetail, type: :model do
 
       populated_respondent_detail.valid?
 
-      expect(populated_respondent_detail.errors.details[:contact_number]).to include a_hash_including(error: :invalid)
+      expect(populated_respondent_detail.errors.details[:contact_number]).to include a_hash_including(error: :invalid_phone_number)
     end
 
     it 'will not validate a mobile_number with more than one "+"' do
@@ -60,7 +60,7 @@ RSpec.describe RespondentsDetail, type: :model do
 
       populated_respondent_detail.valid?
 
-      expect(populated_respondent_detail.errors.details[:mobile_number]).to include a_hash_including(error: :invalid)
+      expect(populated_respondent_detail.errors.details[:mobile_number]).to include a_hash_including(error: :invalid_phone_number)
     end
 
     it 'uses uk_postcode gem to prevent invalid postcodes being saved' do
@@ -68,7 +68,7 @@ RSpec.describe RespondentsDetail, type: :model do
 
       populated_respondent_detail.valid?
 
-      expect(populated_respondent_detail.errors.details[:postcode]).to include a_hash_including(error: :invalid)
+      expect(populated_respondent_detail.errors.details[:postcode]).to include a_hash_including(error: :invalid_postcode)
     end
 
     it 'uses numericality to invalidate employment at site not being a number' do
@@ -364,7 +364,7 @@ RSpec.describe RespondentsDetail, type: :model do
 
       populated_respondent_detail.valid?
 
-      expect(populated_respondent_detail.errors.details[:email_address]).to include a_hash_including(error: :invalid)
+      expect(populated_respondent_detail.errors.details[:email_address]).to include a_hash_including(error: :invalid_email)
     end
 
     it "will not raise a validation error if an email address is provided" do
@@ -384,7 +384,7 @@ RSpec.describe RespondentsDetail, type: :model do
 
       populated_respondent_detail.valid?
 
-      expect(populated_respondent_detail.errors.details[:fax_number]).to include a_hash_including(error: :invalid)
+      expect(populated_respondent_detail.errors.details[:fax_number]).to include a_hash_including(error: :invalid_phone_number)
     end
 
     it "will not raise a validation error if a fax number is provided" do

--- a/spec/forms/your_representatives_details_spec.rb
+++ b/spec/forms/your_representatives_details_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe YourRepresentativesDetails, type: :model do
 
       populated_your_representatives_details.valid?
 
-      expect(populated_your_representatives_details.errors.details[:representative_postcode]).to include a_hash_including(error: :invalid)
+      expect(populated_your_representatives_details.errors.details[:representative_postcode]).to include a_hash_including(error: :invalid_postcode)
     end
 
     it 'will not validate a contact_number with less than 7 integers' do
@@ -38,7 +38,7 @@ RSpec.describe YourRepresentativesDetails, type: :model do
 
       populated_your_representatives_details.valid?
 
-      expect(populated_your_representatives_details.errors.details[:representative_phone]).to include a_hash_including(error: :invalid)
+      expect(populated_your_representatives_details.errors.details[:representative_phone]).to include a_hash_including(error: :invalid_phone_number)
     end
 
     it 'will not validate a mobile_number with letter characters' do
@@ -46,7 +46,7 @@ RSpec.describe YourRepresentativesDetails, type: :model do
 
       populated_your_representatives_details.valid?
 
-      expect(populated_your_representatives_details.errors.details[:representative_mobile]).to include a_hash_including(error: :invalid)
+      expect(populated_your_representatives_details.errors.details[:representative_mobile]).to include a_hash_including(error: :invalid_phone_number)
     end
 
     it 'will not validate an email address without a domain' do
@@ -55,7 +55,7 @@ RSpec.describe YourRepresentativesDetails, type: :model do
 
       populated_your_representatives_details.valid?
 
-      expect(populated_your_representatives_details.errors.details[:representative_email]).to include a_hash_including(error: :invalid)
+      expect(populated_your_representatives_details.errors.details[:representative_email]).to include a_hash_including(error: :invalid_email)
     end
 
     it 'will not validate a fax number with a "+" outside the first character' do
@@ -64,7 +64,7 @@ RSpec.describe YourRepresentativesDetails, type: :model do
 
       populated_your_representatives_details.valid?
 
-      expect(populated_your_representatives_details.errors.details[:representative_fax]).to include a_hash_including(error: :invalid)
+      expect(populated_your_representatives_details.errors.details[:representative_fax]).to include a_hash_including(error: :invalid_phone_number)
     end
 
     it 'will not validate representative disability information over 350 characters' do
@@ -338,7 +338,7 @@ RSpec.describe YourRepresentativesDetails, type: :model do
 
       populated_your_representatives_details.valid?
 
-      expect(populated_your_representatives_details.errors.details[:representative_email]).to include a_hash_including(error: :invalid)
+      expect(populated_your_representatives_details.errors.details[:representative_email]).to include a_hash_including(error: :invalid_email)
     end
 
     it "will not raise a validation error if an email address is provided" do
@@ -356,7 +356,7 @@ RSpec.describe YourRepresentativesDetails, type: :model do
 
       populated_your_representatives_details.valid?
 
-      expect(populated_your_representatives_details.errors.details[:representative_fax]).to include a_hash_including(error: :invalid)
+      expect(populated_your_representatives_details.errors.details[:representative_fax]).to include a_hash_including(error: :invalid_phone_number)
     end
 
     it "will not raise a validation error if a fax number is provided" do

--- a/spec/validators/email_address_validator_spec.rb
+++ b/spec/validators/email_address_validator_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe EmailAddressValidator do
 
     model.valid?
 
-    expect(model.errors.details[:email]).to include a_hash_including(error: :invalid)
+    expect(model.errors.details[:email]).to include a_hash_including(error: :invalid_email)
   end
 
   it 'will not validate an email address with a one character TLD' do
@@ -59,7 +59,7 @@ RSpec.describe EmailAddressValidator do
 
     model.valid?
 
-    expect(model.errors.details[:email]).to include a_hash_including(error: :invalid)
+    expect(model.errors.details[:email]).to include a_hash_including(error: :invalid_email)
   end
 
   it 'will not validate an email address with more than one "@"' do
@@ -67,7 +67,7 @@ RSpec.describe EmailAddressValidator do
 
     model.valid?
 
-    expect(model.errors.details[:email]).to include a_hash_including(error: :invalid)
+    expect(model.errors.details[:email]).to include a_hash_including(error: :invalid_email)
   end
 
   it 'will not validate an email address without a username/recipient' do
@@ -75,7 +75,7 @@ RSpec.describe EmailAddressValidator do
 
     model.valid?
 
-    expect(model.errors.details[:email]).to include a_hash_including(error: :invalid)
+    expect(model.errors.details[:email]).to include a_hash_including(error: :invalid_email)
   end
 
   it 'will not validate an email address without an "@" sign' do
@@ -83,7 +83,7 @@ RSpec.describe EmailAddressValidator do
 
     model.valid?
 
-    expect(model.errors.details[:email]).to include a_hash_including(error: :invalid)
+    expect(model.errors.details[:email]).to include a_hash_including(error: :invalid_email)
   end
 
 end

--- a/spec/validators/persons_name_validator_spec.rb
+++ b/spec/validators/persons_name_validator_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe PersonsNameValidator do
 
     model.valid?
 
-    expect(model.errors.details[:name]).to include a_hash_including(error: :contains_no_spaces)
+    expect(model.errors.details[:name]).to include a_hash_including(error: :invalid_name)
   end
 
 end

--- a/spec/validators/phone_number_validator_spec.rb
+++ b/spec/validators/phone_number_validator_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe PhoneNumberValidator do
 
     model.valid?
 
-    expect(model.errors.details[:number]).to include a_hash_including(error: :invalid)
+    expect(model.errors.details[:number]).to include a_hash_including(error: :invalid_phone_number)
   end
 
   it 'will validate a string of integers with spaces' do
@@ -35,7 +35,7 @@ RSpec.describe PhoneNumberValidator do
 
     model.valid?
 
-    expect(model.errors.details[:number]).to include a_hash_including(error: :invalid)
+    expect(model.errors.details[:number]).to include a_hash_including(error: :invalid_phone_number)
   end
 
   it 'will validate a string that starts with an international call code' do
@@ -51,7 +51,7 @@ RSpec.describe PhoneNumberValidator do
 
     model.valid?
 
-    expect(model.errors.details[:number]).to include a_hash_including(error: :invalid)
+    expect(model.errors.details[:number]).to include a_hash_including(error: :invalid_phone_number)
   end
 
   it 'will validate a string with 7 integers and dashes' do

--- a/spec/validators/postcode_validator_spec.rb
+++ b/spec/validators/postcode_validator_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe PostcodeValidator do
 
     model.valid?
 
-    expect(model.errors.details[:postcode]).to include a_hash_including(error: :invalid)
+    expect(model.errors.details[:postcode]).to include a_hash_including(error: :invalid_postcode)
   end
 
   it 'will return an error when nil' do

--- a/test_common/messaging/en.yml
+++ b/test_common/messaging/en.yml
@@ -259,6 +259,17 @@ en:
       not_a_number: is not a number
       too_long: characters is the maximum allowed
       inclusion: Please select an option
+    custom:
+      organisation_employ_gb:
+        not_a_number: Please enter how many people the organisation employs in Great Britain as a number
+      organisation_more_than_one_site:
+        not_a_number: Please enter how many people are employed at the place where the claimant worked as a number
+      queried_hours:
+        not_a_number: Please enter the number of hours you believe to be correct as a number
+      queried_pay_before_tax:
+        not_a_number: Please enter the pay before tax as a number
+      queried_take_home_pay:
+        not_a_number: Please enter the normal take-home pay as a number
   links:
     confirmation_of_supplied_details:
       edit_page: Edit answers on this page

--- a/test_common/messaging/en.yml
+++ b/test_common/messaging/en.yml
@@ -252,10 +252,13 @@ en:
       contains_no_spaces: must contain at least one space
       contains_numbers: must not contain numbers
       invalid: is invalid
+      invalid_email: This is not a valid email address
+      invalid_name: Please enter your full name
+      invalid_postcode: This is not a valid UK postcode
+      invalid_phone_number: This is not a valid phone number
       not_a_number: is not a number
       too_long: characters is the maximum allowed
-      inclusion: is not included in the list
-      confirmation: doesn't match
+      inclusion: Please select an option
   links:
     confirmation_of_supplied_details:
       edit_page: Edit answers on this page

--- a/test_common/page_objects/claimants_details_page.rb
+++ b/test_common/page_objects/claimants_details_page.rb
@@ -8,7 +8,7 @@ module ET3
       section :claimants_name_question, :question_labelled, 'questions.claimants_name.label', exact: false do
         element :field, :css, "input"
         element :error_contains_numbers, :exact_error_text, 'errors.messages.contains_numbers', exact: false
-        element :error_contains_no_spaces, :exact_error_text, 'errors.messages.contains_no_spaces', exact: false
+        element :error_invalid_name, :exact_error_text, 'errors.messages.invalid_name', exact: false
 
 
         delegate :set, to: :field

--- a/test_common/page_objects/confirmation_of_supplied_details_page.rb
+++ b/test_common/page_objects/confirmation_of_supplied_details_page.rb
@@ -7,7 +7,7 @@ module ET3
 
       section :email_receipt_question, :question_labelled, 'questions.email_receipt.label', exact: false do
         element :field, :css, 'input'
-        element :error_invalid, :exact_error_text, 'errors.messages.invalid', exact: false
+        element :error_invalid_email, :exact_error_text, 'errors.messages.invalid_email', exact: false
 
         delegate :set, to: :field
       end

--- a/test_common/page_objects/earnings_and_benefits_page.rb
+++ b/test_common/page_objects/earnings_and_benefits_page.rb
@@ -15,7 +15,7 @@ module ET3
           delegate :set, to: :field
         end
 
-        element :error_not_a_number, :exact_error_text, 'errors.messages.not_a_number', exact: false
+        element :error_not_a_number, :exact_error_text, 'errors.custom.queried_hours.not_a_number', exact: false
 
         def set_for(user_persona)
           if user_persona.agree_with_claimants_hours == 'No'
@@ -49,6 +49,7 @@ module ET3
             delegate :set, to: :selector
           end
 
+          element :error_not_a_number, :exact_error_text, 'errors.custom.queried_pay_before_tax.not_a_number', exact: false
           delegate :set, to: :field
 
         end
@@ -71,11 +72,11 @@ module ET3
             delegate :set, to: :selector
           end
 
+          element :error_not_a_number, :exact_error_text, 'errors.custom.queried_take_home_pay.not_a_number', exact: false
+
           delegate :set, to: :field
         end
         
-        element :error_not_a_number, :exact_error_text, 'errors.messages.not_a_number', exact: false
-
         def set_for(user_persona)
           if user_persona.agree_with_earnings_details == 'No'
             no.set(true)

--- a/test_common/page_objects/respondents_details_page.rb
+++ b/test_common/page_objects/respondents_details_page.rb
@@ -22,7 +22,7 @@ module ET3
       section :contact_question, :question_labelled, 'questions.contact.label', exact: false do
         element :field, :css, "input"
         element :error_contains_numbers, :exact_error_text, 'errors.messages.contains_numbers', exact: false
-        element :error_contains_no_spaces, :exact_error_text, 'errors.messages.contains_no_spaces', exact: false
+        element :error_contains_invalid_name, :exact_error_text, 'errors.messages.invalid_name', exact: false
 
         delegate :set, to: :field
       end
@@ -57,7 +57,7 @@ module ET3
       section :postcode_question, :question_labelled, 'questions.postcode.label', exact: false do
         element :field, :css, "input"
         element :error_blank, :exact_error_text, 'errors.messages.blank', exact: false
-        element :error_invalid, :exact_error_text, 'errors.messages.invalid', exact: false
+        element :error_invalid_postcode, :exact_error_text, 'errors.messages.invalid_postcode', exact: false
 
         delegate :set, to: :field
       end
@@ -70,14 +70,14 @@ module ET3
             
       section :contact_number_question, :question_labelled, 'questions.contact_number.label', exact: false do
         element :field, :css, "input"
-        element :error_invalid, :exact_error_text, 'errors.messages.invalid', exact: false
+        element :error_invalid_phone_number, :exact_error_text, 'errors.messages.invalid_phone_number', exact: false
 
         delegate :set, to: :field
       end
             
       section :contact_mobile_number_question, :question_labelled, 'questions.contact_mobile_number.label', exact: false do
         element :field, :css, "input"
-        element :error_invalid, :exact_error_text, 'errors.messages.invalid', exact: false
+        element :error_invalid_phone_number, :exact_error_text, 'errors.messages.invalid_phone_number', exact: false
 
         delegate :set, to: :field
       end
@@ -110,8 +110,8 @@ module ET3
           delegate :set, to: :root_element
         end
 
-        element :error_invalid_email, :exact_error_text, 'errors.messages.invalid', exact: false
-        element :error_invalid_fax, :exact_error_text, 'errors.messages.invalid', exact: false
+        element :error_invalid_email, :exact_error_text, 'errors.messages.invalid_email', exact: false
+        element :error_invalid_fax, :exact_error_text, 'errors.messages.invalid_phone_number', exact: false
 
         def set_for(user_persona)
           case user_persona.contact_preference

--- a/test_common/page_objects/respondents_details_page.rb
+++ b/test_common/page_objects/respondents_details_page.rb
@@ -33,21 +33,21 @@ module ET3
 
         delegate :set, to: :field
       end
-      
+
       section :street_question, :question_labelled, 'questions.street.label', exact: false do
         element :field, :css, "input"
         element :error_blank, :exact_error_text, 'errors.messages.blank', exact: false
 
         delegate :set, to: :field
       end
-            
+
       section :town_question, :question_labelled, 'questions.town.label', exact: false do
         element :field, :css, "input"
         element :error_blank, :exact_error_text, 'errors.messages.blank', exact: false
 
         delegate :set, to: :field
       end
-            
+
       section :county_question, :question_labelled, 'questions.county.label', exact: false do
         element :field, :css, "input"
 
@@ -61,20 +61,20 @@ module ET3
 
         delegate :set, to: :field
       end
-            
+
       section :dx_number_question, :question_labelled, 'questions.dx_number.label', exact: false do
         element :field, :css, "input"
 
         delegate :set, to: :field
       end
-            
+
       section :contact_number_question, :question_labelled, 'questions.contact_number.label', exact: false do
         element :field, :css, "input"
         element :error_invalid_phone_number, :exact_error_text, 'errors.messages.invalid_phone_number', exact: false
 
         delegate :set, to: :field
       end
-            
+
       section :contact_mobile_number_question, :question_labelled, 'questions.contact_mobile_number.label', exact: false do
         element :field, :css, "input"
         element :error_invalid_phone_number, :exact_error_text, 'errors.messages.invalid_phone_number', exact: false
@@ -126,30 +126,30 @@ module ET3
           end
         end
       end
-            
+
       section :organisation_employ_gb_question, :question_labelled, 'questions.organisation_employ_gb.label', exact: false do
         element :field, :css, "input"
         element :error_blank, :exact_error_text, 'errors.messages.blank', exact: false
-        element :error_not_a_number, :exact_error_text, 'errors.messages.not_a_number', exact: false
+        element :error_not_a_number, :exact_error_text, 'errors.custom.organisation_employ_gb.not_a_number', exact: false
 
         delegate :set, to: :field
       end
-      
+
       section :organisation_more_than_one_site_question, :single_choice_option, 'questions.organisation_more_than_one_site.label', exact: false do |q|
-        
+
         include SingleChoiceOptionSection
 
         section :employment_at_site_number, :inputtext_labelled, 'questions.organisation_more_than_one_site.employment_at_site_number.label', exact: false do
           delegate :set, to: :root_element
         end
 
-        element :error_not_a_number, :exact_error_text, 'errors.messages.not_a_number', exact: false
+        element :error_not_a_number, :exact_error_text, 'errors.custom.organisation_more_than_one_site.not_a_number', exact: false
 
         def set_for(user_persona)
           if user_persona.organisation_more_than_one_site == 'Yes'
             yes.set(true)
             employment_at_site_number.set(user_persona.employment_at_site_number)
-          else 
+          else
             no.set(true)
           end
         end

--- a/test_common/page_objects/your_representatives_details_page.rb
+++ b/test_common/page_objects/your_representatives_details_page.rb
@@ -90,6 +90,8 @@ module ET3
         element :field, :css, "input"
 
         element :error_contains_numbers, :exact_error_text, 'errors.messages.contains_numbers', exact: false
+        element :error_blank, :exact_error_text, 'errors.messages.blank', exact: false
+        element :error_invalid_name, :exact_error_text, 'errors.messages.invalid_name', exact: false
 
         delegate :set, to: :field
       end
@@ -127,7 +129,7 @@ module ET3
       section :representative_postcode_question, :question_labelled, 'questions.representative_postcode.label', exact: false do
         element :field, :css, "input"
 
-        element :error_invalid, :exact_error_text, 'errors.messages.invalid', exact: false
+        element :error_invalid_postcode, :exact_error_text, 'errors.messages.invalid_postcode', exact: false
 
         delegate :set, to: :field
       end
@@ -135,7 +137,7 @@ module ET3
       section :representative_phone_question, :question_labelled, 'questions.representative_phone.label', exact: false do
         element :field, :css, "input"
 
-        element :error_invalid, :exact_error_text, 'errors.messages.invalid', exact: false
+        element :error_invalid_phone_number, :exact_error_text, 'errors.messages.invalid_phone_number', exact: false
 
         delegate :set, to: :field
       end
@@ -143,7 +145,7 @@ module ET3
       section :representative_mobile_question, :question_labelled, 'questions.representative_mobile.label', exact: false do
         element :field, :css, "input"
 
-        element :error_invalid, :exact_error_text, 'errors.messages.invalid', exact: false
+        element :error_invalid_phone_number, :exact_error_text, 'errors.messages.invalid_phone_number', exact: false
 
         delegate :set, to: :field
       end
@@ -188,7 +190,8 @@ module ET3
           delegate :set, to: :root_element
         end
 
-        element :error_invalid, :exact_error_text, 'errors.messages.invalid', exact: false
+        element :error_invalid_email, :exact_error_text, 'errors.messages.invalid_email', exact: false
+        element :error_invalid_fax, :exact_error_text, 'errors.messages.invalid_phone_number', exact: false
 
         def set_for(user_persona)
           case user_persona.representative_contact_preference


### PR DESCRIPTION
Updates errors, removing `(optional)` from error fields and providing better feedback to the user. Heavily based on @AlexaVB's changes in RST-1127 but I overhauled error messages across the board.