### PR TITLE
RST-1238: Upload doesn't work when revisiting page

### DIFF
--- a/app/views/additional_informations/edit.html.slim
+++ b/app/views/additional_informations/edit.html.slim
@@ -1,5 +1,6 @@
 - content_for :form_page_title, "Additional Information"
 - content_for :page_title, raw("#{content_for :form_page_title} - Response to Claim - MoJ")
+- content_for :page_head, raw('<meta name="turbolinks-visit-control" content="reload">')
 .content-body.additional-information
 
   p = t('helpers.label.additional_information.upload_additional_information')

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -1,6 +1,7 @@
 - content_for :head
   = stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload'
   = javascript_include_tag 'application'
+  = yield(:page_head)
 - content_for :body_end
   javascript:
     var showHideContent = new GOVUK.ShowHideContent();


### PR DESCRIPTION
**Force upload page to refresh on page load**

Before this change, uploading a file, progressing and then returning to the page would break the upload functionality. A new file could not be uploaded without reloading the page.

The page now informs Turbolinks that it needs to be loaded from fresh every time.