### PR TITLE
RST-1273: Enable user to remove rtf file from ET3

### DIFF
--- a/app/controllers/confirmation_of_supplied_details_controller.rb
+++ b/app/controllers/confirmation_of_supplied_details_controller.rb
@@ -16,6 +16,12 @@ class ConfirmationOfSuppliedDetailsController < ApplicationController
     end
   end
 
+  def destroy_rtf
+    current_store.hash_store[:additional_information_answers].delete(:upload_additional_information)
+    current_store.hash_store[:additional_information_answers].delete(:upload_file_name)
+    redirect_to edit_confirmation_of_supplied_details_path
+  end
+
   private
 
   def confirmation_of_supplied_details_params

--- a/app/views/confirmation_of_supplied_details/edit.html.slim
+++ b/app/views/confirmation_of_supplied_details/edit.html.slim
@@ -287,7 +287,13 @@
           th Answer
         tr
           td = t('helpers.label.additional_information.upload_additional_information')
-          td = @hash_store.dig(:additional_information_answers, :upload_file_name)
+          td
+            - if @hash_store.dig(:additional_information_answers, :upload_file_name)
+              = @hash_store[:additional_information_answers][:upload_file_name]
+              br
+              = link_to 'Remove file', remove_rtf_path, method: :delete
+
+          / @hash_store.dig(:additional_information_answers, :upload_file_name)
         tr
           td
             = link_to("Edit answers on this page", edit_additional_information_path)

--- a/app/views/confirmation_of_supplied_details/edit.html.slim
+++ b/app/views/confirmation_of_supplied_details/edit.html.slim
@@ -292,12 +292,10 @@
               = @hash_store[:additional_information_answers][:upload_file_name]
               br
               = link_to 'Remove file', remove_rtf_path, method: :delete
-
-          / @hash_store.dig(:additional_information_answers, :upload_file_name)
         tr
           td
             = link_to("Edit answers on this page", edit_additional_information_path)
           td
             = link_to "Back to the top", "#content"
-    br/
+    br
     = f.submit("Submit Form", class: 'button')

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -1,6 +1,7 @@
 - content_for :head
   = stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload'
   = javascript_include_tag 'application'
+  = csrf_meta_tags
   = yield(:page_head)
 - content_for :body_end
   javascript:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,6 +14,7 @@ Rails.application.routes.draw do
   end
   root 'static_pages#index'
   get "/session_expired" => 'static_pages#expired'
+  delete "/respond/confirmation_of_supplied_details/remove_rtf" => 'confirmation_of_supplied_details#destroy_rtf', as: :remove_rtf
   mount ApiProxy.new(backend: "#{ENV.fetch('ET_API_URL', 'http://api.et.127.0.0.1.nip.io:3100/api')}/v2/s3/create_signed_url", streaming: false), at: "/api/s3/create_signed_url"
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 end


### PR DESCRIPTION
Users could only overwrite the rtf file before, they could not delete it and submit nothing.