### PR TITLE
RST-1278 Fix static assets

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ RUN npm install
 
 EXPOSE 8080
 
-RUN bundle exec rake assets:precompile RAILS_ENV=production SECRET_KEY_BASE=foobar
+RUN bundle exec rails assets:precompile RAILS_ENV=production SECRET_KEY_BASE=foobar
+RUN bundle exec rake non_digest_assets RAILS_ENV=production SECRET_KEY_BASE=foobar
 
 CMD ["./run.sh"]

--- a/lib/tasks/non_digest_assets.rake
+++ b/lib/tasks/non_digest_assets.rake
@@ -1,0 +1,16 @@
+# Source:
+# https://github.com/rails/sprockets-rails/issues/49#issuecomment-20535134
+
+task non_digest_assets: :environment do
+  assets = Dir.glob(Rails.root.join('public', 'assets', '**', '*'))
+  regex = /(-{1}[a-z0-9]{32}*\.{1}){1}/
+  assets.each do |file|
+    next if File.directory?(file) || file !~ regex
+
+    source = file.split('/')
+    source.push(source.pop.gsub(regex, '.'))
+
+    non_digested = File.join(source)
+    FileUtils.cp(file, non_digested)
+  end
+end

--- a/public/404.html
+++ b/public/404.html
@@ -7,22 +7,22 @@
     <title>Page Not Found - Response to Claim - MoJ</title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <!--[if gt IE 8]><!-->
-    <link rel="stylesheet" media="screen" href="assets/govuk-template.css" crossorigin="anonymous">
+    <link rel="stylesheet" media="screen" href="/assets/govuk-template.css" crossorigin="anonymous">
     <!--<![endif]-->
-    <link rel="stylesheet" media="print" href="assets/govuk-template-print.css" crossorigin="anonymous">
+    <link rel="stylesheet" media="print" href="/assets/govuk-template-print.css" crossorigin="anonymous">
 
     <!--[if gte IE 9]><!-->
-    <link rel="stylesheet" media="all" href="assets/fonts.css" crossorigin="anonymous">
+    <link rel="stylesheet" media="all" href="/assets/fonts.css" crossorigin="anonymous">
     <!--<![endif]-->
 
     <meta name="theme-color" content="#0b0c0c">
 
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
-    <link rel="stylesheet" media="all" href="assets/elements.css" data-turbolinks-track="reload">
-    <link rel="stylesheet" media="all" href="assets/application.css" data-turbolinks-track="reload">
-    <script src="assets/jquery.js"></script>
-    <script src="assets/application.js"></script>
+    <link rel="stylesheet" media="all" href="/assets/elements.css" data-turbolinks-track="reload">
+    <link rel="stylesheet" media="all" href="/assets/application.css" data-turbolinks-track="reload">
+    <script src="/assets/jquery.js"></script>
+    <script src="/assets/application.js"></script>
 </head>
 
 <body class="js-enabled">
@@ -110,7 +110,7 @@
 
 <div id="global-app-error" class="app-error hidden"></div>
 
-<script src="assets/govuk-template.js" crossorigin="anonymous"></script>
+<script src="/assets/govuk-template.js" crossorigin="anonymous"></script>
 
 <script>
     if (typeof window.GOVUK === 'undefined') document.body.className = document.body.className.replace('js-enabled', '');


### PR DESCRIPTION
This is a precursor to the ET3 mailer from ET API, can now use the assets at `<et3-url>/assets/govuk-template.css`, etc.