### PR TITLE
RST-1284 Fix conditional data being submitted unnecessarily

### DIFF
--- a/app/forms/claimants_detail.rb
+++ b/app/forms/claimants_detail.rb
@@ -21,13 +21,13 @@ class ClaimantsDetail < BaseForm
       agree_with_claimants_description_of_job_or_title: agree_with_claimants_description_of_job_or_title,
     }
 
-    claimants_detail_hash.merge!(disagree_conciliation_reason: disagree_conciliation_reason) if claimants_detail_hash[:agree_with_early_conciliation_details] == false
+    claimants_detail_hash[:disagree_conciliation_reason] = disagree_conciliation_reason if claimants_detail_hash[:agree_with_early_conciliation_details] == false
     if claimants_detail_hash[:agree_with_employment_dates] == false
       claimants_detail_hash.merge!(employment_start: employment_start,
                                    employment_end: employment_end,
                                    disagree_employment: disagree_employment)
     end
-    claimants_detail_hash.merge!(disagree_claimants_job_or_title: disagree_claimants_job_or_title) if claimants_detail_hash[:agree_with_claimants_description_of_job_or_title] == false
+    claimants_detail_hash[:disagree_claimants_job_or_title] = disagree_claimants_job_or_title if claimants_detail_hash[:agree_with_claimants_description_of_job_or_title] == false
 
     claimants_detail_hash
   end

--- a/app/forms/claimants_detail.rb
+++ b/app/forms/claimants_detail.rb
@@ -13,18 +13,23 @@ class ClaimantsDetail < BaseForm
   attribute :disagree_claimants_job_or_title, :text
 
   def to_h # rubocop:disable Metrics/MethodLength
-    {
+    claimants_detail_hash = {
       claimants_name: claimants_name,
       agree_with_early_conciliation_details: agree_with_early_conciliation_details,
-      disagree_conciliation_reason: disagree_conciliation_reason,
       agree_with_employment_dates: agree_with_employment_dates,
-      employment_start: employment_start,
-      employment_end: employment_end,
-      disagree_employment: disagree_employment,
       continued_employment: continued_employment,
       agree_with_claimants_description_of_job_or_title: agree_with_claimants_description_of_job_or_title,
-      disagree_claimants_job_or_title: disagree_claimants_job_or_title
     }
+
+    claimants_detail_hash.merge!(disagree_conciliation_reason: disagree_conciliation_reason) if claimants_detail_hash[:agree_with_early_conciliation_details] == false
+    if claimants_detail_hash[:agree_with_employment_dates] == false
+      claimants_detail_hash.merge!(employment_start: employment_start,
+                                   employment_end: employment_end,
+                                   disagree_employment: disagree_employment)
+    end
+    claimants_detail_hash.merge!(disagree_claimants_job_or_title: disagree_claimants_job_or_title) if claimants_detail_hash[:agree_with_claimants_description_of_job_or_title] == false
+
+    claimants_detail_hash
   end
 
   validates :claimants_name,

--- a/app/forms/earnings_and_benefits.rb
+++ b/app/forms/earnings_and_benefits.rb
@@ -12,33 +12,62 @@ class EarningsAndBenefits < BaseForm
   attribute :disagree_claimant_pension_benefits_reason, :text
 
   def to_h # rubocop:disable Metrics/MethodLength
-    {
+    earnings_and_benefits_hash = {
       agree_with_claimants_hours: agree_with_claimants_hours,
-      queried_hours: queried_hours,
       agree_with_earnings_details: agree_with_earnings_details,
-      queried_pay_before_tax: queried_pay_before_tax,
-      queried_pay_before_tax_period: queried_pay_before_tax_period,
-      queried_take_home_pay: queried_take_home_pay,
-      queried_take_home_pay_period: queried_take_home_pay_period,
       agree_with_claimant_notice: agree_with_claimant_notice,
-      disagree_claimant_notice_reason: disagree_claimant_notice_reason,
       agree_with_claimant_pension_benefits: agree_with_claimant_pension_benefits,
-      disagree_claimant_pension_benefits_reason: disagree_claimant_pension_benefits_reason
     }
+
+    earnings_and_benefits_hash.merge!(queried_hours: queried_hours) if earnings_and_benefits_hash[:agree_with_claimants_hours] == false
+    if earnings_and_benefits_hash[:agree_with_earnings_details] == false
+      earnings_and_benefits_hash.merge!(queried_pay_before_tax: queried_pay_before_tax,
+                                        queried_pay_before_tax_period: queried_pay_before_tax_period,
+                                        queried_take_home_pay: queried_take_home_pay,
+                                        queried_take_home_pay_period: queried_take_home_pay_period)
+    end
+    earnings_and_benefits_hash.merge!(disagree_claimant_notice_reason: disagree_claimant_notice_reason) if earnings_and_benefits_hash[:agree_with_claimant_notice] == false
+    earnings_and_benefits_hash.merge!(disagree_claimant_pension_benefits_reason: disagree_claimant_pension_benefits_reason) if earnings_and_benefits_hash[:agree_with_claimant_pension_benefits] == false
+
+    earnings_and_benefits_hash
   end
 
-  validates :queried_hours, :queried_pay_before_tax, :queried_take_home_pay,
+  validates :queried_hours,
     numericality: true,
-    allow_nil: true
+    allow_nil: true,
+    if: :disagree_claimants_hours?
+  validates :queried_pay_before_tax, :queried_take_home_pay,
+    numericality: true,
+    allow_nil: true,
+    if: :disagree_earnings_details?
   validates :disagree_claimant_notice_reason,
     length: {
       maximum: 400,
       too_long: "%{count} characters is the maximum allowed" # rubocop:disable Style/FormatStringToken
-    }
+    },
+    if: :disagree_claimants_notice?
   validates :disagree_claimant_pension_benefits_reason,
     length: {
       maximum: 350,
       too_long: "%{count} characters is the maximum allowed" # rubocop:disable Style/FormatStringToken
-    }
+    },
+    if: :disagree_claimants_pension_benefits?
 
+  private
+
+  def disagree_claimants_hours?
+    agree_with_claimants_hours == false
+  end
+
+  def disagree_earnings_details?
+    agree_with_earnings_details == false
+  end
+
+  def disagree_claimants_notice?
+    agree_with_claimant_notice == false
+  end
+
+  def disagree_claimants_pension_benefits?
+    agree_with_claimant_pension_benefits == false
+  end
 end

--- a/app/forms/earnings_and_benefits.rb
+++ b/app/forms/earnings_and_benefits.rb
@@ -19,15 +19,15 @@ class EarningsAndBenefits < BaseForm
       agree_with_claimant_pension_benefits: agree_with_claimant_pension_benefits,
     }
 
-    earnings_and_benefits_hash.merge!(queried_hours: queried_hours) if earnings_and_benefits_hash[:agree_with_claimants_hours] == false
+    earnings_and_benefits_hash[:queried_hours] = queried_hours if earnings_and_benefits_hash[:agree_with_claimants_hours] == false
     if earnings_and_benefits_hash[:agree_with_earnings_details] == false
       earnings_and_benefits_hash.merge!(queried_pay_before_tax: queried_pay_before_tax,
                                         queried_pay_before_tax_period: queried_pay_before_tax_period,
                                         queried_take_home_pay: queried_take_home_pay,
                                         queried_take_home_pay_period: queried_take_home_pay_period)
     end
-    earnings_and_benefits_hash.merge!(disagree_claimant_notice_reason: disagree_claimant_notice_reason) if earnings_and_benefits_hash[:agree_with_claimant_notice] == false
-    earnings_and_benefits_hash.merge!(disagree_claimant_pension_benefits_reason: disagree_claimant_pension_benefits_reason) if earnings_and_benefits_hash[:agree_with_claimant_pension_benefits] == false
+    earnings_and_benefits_hash[:disagree_claimant_notice_reason] = disagree_claimant_notice_reason if earnings_and_benefits_hash[:agree_with_claimant_notice] == false
+    earnings_and_benefits_hash[:disagree_claimant_pension_benefits_reason] = disagree_claimant_pension_benefits_reason if earnings_and_benefits_hash[:agree_with_claimant_pension_benefits] == false
 
     earnings_and_benefits_hash
   end

--- a/app/forms/employers_contract_claim.rb
+++ b/app/forms/employers_contract_claim.rb
@@ -7,7 +7,7 @@ class EmployersContractClaim < BaseForm
       make_employer_contract_claim: make_employer_contract_claim
     }
 
-    employer_contract_claim_hash.merge!(claim_information: claim_information) if employer_contract_claim_hash[:make_employer_contract_claim]
+    employer_contract_claim_hash[:claim_information] = claim_information if employer_contract_claim_hash[:make_employer_contract_claim]
 
     employer_contract_claim_hash
   end

--- a/app/forms/employers_contract_claim.rb
+++ b/app/forms/employers_contract_claim.rb
@@ -3,15 +3,25 @@ class EmployersContractClaim < BaseForm
   attribute :claim_information, :text
 
   def to_h
-    {
-      make_employer_contract_claim: make_employer_contract_claim,
-      claim_information: claim_information
+    employer_contract_claim_hash = {
+      make_employer_contract_claim: make_employer_contract_claim
     }
+
+    employer_contract_claim_hash.merge!(claim_information: claim_information) if employer_contract_claim_hash[:make_employer_contract_claim]
+
+    employer_contract_claim_hash
   end
 
   validates :claim_information,
     length: {
       maximum: 4500,
       too_long: "%{count} characters is the maximum allowed" # rubocop:disable Style/FormatStringToken
-    }
+    },
+    if: :make_claim?
+
+  private
+
+  def make_claim?
+    make_employer_contract_claim
+  end
 end

--- a/app/forms/respondents_detail.rb
+++ b/app/forms/respondents_detail.rb
@@ -35,9 +35,9 @@ class RespondentsDetail < BaseForm
       organisation_more_than_one_site: organisation_more_than_one_site,
     }
 
-    respondents_detail_hash.merge!(email_address: email_address) if respondents_detail_hash[:contact_preference] == "email"
-    respondents_detail_hash.merge!(fax_number: fax_number) if respondents_detail_hash[:contact_preference] == "fax"
-    respondents_detail_hash.merge!(employment_at_site_number: employment_at_site_number) if respondents_detail_hash[:organisation_more_than_one_site]
+    respondents_detail_hash[:email_address] = email_address if respondents_detail_hash[:contact_preference] == "email"
+    respondents_detail_hash[:fax_number] = fax_number if respondents_detail_hash[:contact_preference] == "fax"
+    respondents_detail_hash[:employment_at_site_number] = employment_at_site_number if respondents_detail_hash[:organisation_more_than_one_site]
 
     respondents_detail_hash
   end

--- a/app/forms/respondents_detail.rb
+++ b/app/forms/respondents_detail.rb
@@ -18,7 +18,7 @@ class RespondentsDetail < BaseForm
   attribute :employment_at_site_number, :integer
 
   def to_h # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
-    {
+    respondents_detail_hash = {
       case_number: case_number,
       name: name,
       contact: contact,
@@ -31,12 +31,15 @@ class RespondentsDetail < BaseForm
       contact_number: contact_number,
       mobile_number: mobile_number,
       contact_preference: contact_preference,
-      email_address: email_address,
-      fax_number: fax_number,
       organisation_employ_gb: organisation_employ_gb,
       organisation_more_than_one_site: organisation_more_than_one_site,
-      employment_at_site_number: employment_at_site_number
     }
+
+    respondents_detail_hash.merge!(email_address: email_address) if respondents_detail_hash[:contact_preference] == "email"
+    respondents_detail_hash.merge!(fax_number: fax_number) if respondents_detail_hash[:contact_preference] == "fax"
+    respondents_detail_hash.merge!(employment_at_site_number: employment_at_site_number) if respondents_detail_hash[:organisation_more_than_one_site]
+
+    respondents_detail_hash
   end
 
   validates :name, :building_name, :street_name, :town, presence: true

--- a/app/forms/response.rb
+++ b/app/forms/response.rb
@@ -7,7 +7,7 @@ class Response < BaseForm
       defend_claim: defend_claim,
     }
 
-    response_hash.merge!(defend_claim_facts: defend_claim_facts) if response_hash[:defend_claim]
+    response_hash[:defend_claim_facts] = defend_claim_facts if response_hash[:defend_claim]
 
     response_hash
   end

--- a/app/forms/response.rb
+++ b/app/forms/response.rb
@@ -3,10 +3,13 @@ class Response < BaseForm
   attribute :defend_claim_facts, :text
 
   def to_h
-    {
+    response_hash = {
       defend_claim: defend_claim,
-      defend_claim_facts: defend_claim_facts
     }
+
+    response_hash.merge!(defend_claim_facts: defend_claim_facts) if response_hash[:defend_claim]
+
+    response_hash
   end
 
   validates :defend_claim,
@@ -15,5 +18,12 @@ class Response < BaseForm
     length: {
       maximum: 2500,
       too_long: "%{count} characters is the maximum allowed" # rubocop:disable Style/FormatStringToken
-    }
+    },
+    if: :defend_claim?
+
+  private
+
+  def defend_claim?
+    defend_claim
+  end
 end

--- a/app/forms/your_representatives_details.rb
+++ b/app/forms/your_representatives_details.rb
@@ -35,9 +35,9 @@ class YourRepresentativesDetails < BaseForm
       representative_disability: representative_disability
     }
 
-    representatives_detail_hash.merge!(representative_email: representative_email) if representatives_detail_hash[:representative_contact_preference] == "email"
-    representatives_detail_hash.merge!(representative_fax: representative_fax) if representatives_detail_hash[:representative_contact_preference] == "fax"
-    representatives_detail_hash.merge!(representative_disability_information: representative_disability_information) if representatives_detail_hash[:representative_disability]
+    representatives_detail_hash[:representative_email] = representative_email if representatives_detail_hash[:representative_contact_preference] == "email"
+    representatives_detail_hash[:representative_fax] = representative_fax if representatives_detail_hash[:representative_contact_preference] == "fax"
+    representatives_detail_hash[:representative_disability_information] = representative_disability_information if representatives_detail_hash[:representative_disability]
 
     representatives_detail_hash
   end

--- a/app/forms/your_representatives_details.rb
+++ b/app/forms/your_representatives_details.rb
@@ -18,7 +18,7 @@ class YourRepresentativesDetails < BaseForm
   attribute :representative_disability_information, :text
 
   def to_h # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
-    {
+    representatives_detail_hash = {
       type_of_representative: type_of_representative,
       representative_org_name: representative_org_name,
       representative_name: representative_name,
@@ -32,11 +32,14 @@ class YourRepresentativesDetails < BaseForm
       representative_dx_number: representative_dx_number,
       representative_reference: representative_reference,
       representative_contact_preference: representative_contact_preference,
-      representative_email: representative_email,
-      representative_fax: representative_fax,
-      representative_disability: representative_disability,
-      representative_disability_information: representative_disability_information
+      representative_disability: representative_disability
     }
+
+    representatives_detail_hash.merge!(representative_email: representative_email) if representatives_detail_hash[:representative_contact_preference] == "email"
+    representatives_detail_hash.merge!(representative_fax: representative_fax) if representatives_detail_hash[:representative_contact_preference] == "fax"
+    representatives_detail_hash.merge!(representative_disability_information: representative_disability_information) if representatives_detail_hash[:representative_disability]
+
+    representatives_detail_hash
   end
 
   validates :type_of_representative,

--- a/spec/forms/claimants_detail_spec.rb
+++ b/spec/forms/claimants_detail_spec.rb
@@ -247,6 +247,8 @@ RSpec.describe ClaimantsDetail, type: :model do
       populated_claimant_detail.agree_with_employment_dates = false
       populated_claimant_detail.employment_end = nil
 
+      populated_claimant_detail.valid?
+
       expect(populated_claimant_detail.errors.details[:employment_end]).to include a_hash_including(error: :blank)
     end
 

--- a/spec/forms/claimants_detail_spec.rb
+++ b/spec/forms/claimants_detail_spec.rb
@@ -171,14 +171,65 @@ RSpec.describe ClaimantsDetail, type: :model do
     end
   end
 
+  context "when agreeing with early conciliation reason" do
+    it 'will not hash disagree conciliation reason' do
+      populated_claimant_detail.agree_with_early_conciliation_details = true
+      populated_claimant_detail.disagree_conciliation_reason = "will not be hashed"
+
+      expect(populated_claimant_detail.to_h).not_to include(:disagree_conciliation_reason)
+    end
+  end
+
   context "when disagreeing with early conciliation reason" do
     it 'will not raise a validation error on disagree conciliation reason' do
       populated_claimant_detail.agree_with_early_conciliation_details = false
       populated_claimant_detail.disagree_conciliation_reason = nil
 
-      populated_claimant_detail.valid?
+      expect(populated_claimant_detail).to be_valid
+    end
+  end
+
+  context "when agreeing with employment dates" do
+    it 'will not validate employment start' do
+      populated_claimant_detail.agree_with_employment_dates = true
+      populated_claimant_detail.employment_start = ""
 
       expect(populated_claimant_detail).to be_valid
+    end
+
+    it 'will not validate employment end' do
+      populated_claimant_detail.agree_with_employment_dates = true
+      populated_claimant_detail.employment_end = ""
+
+      expect(populated_claimant_detail).to be_valid
+    end
+
+    it 'will not validate disagree employment dates' do
+      populated_claimant_detail.agree_with_employment_dates = true
+      populated_claimant_detail.disagree_employment = ""
+
+      expect(populated_claimant_detail).to be_valid
+    end
+
+    it 'will not hash employment start' do
+      populated_claimant_detail.agree_with_employment_dates = true
+      populated_claimant_detail.employment_start = '01/01/2017'
+
+      expect(populated_claimant_detail.to_h).not_to include(:employment_start)
+    end
+
+    it 'will not hash employment end' do
+      populated_claimant_detail.agree_with_employment_dates = true
+      populated_claimant_detail.employment_end = '31/12/2017'
+
+      expect(populated_claimant_detail.to_h).not_to include(:employment_end)
+    end
+
+    it 'will not hash disagree employment dates' do
+      populated_claimant_detail.agree_with_employment_dates = true
+      populated_claimant_detail.disagree_employment = 'disagree employment reason'
+
+      expect(populated_claimant_detail.to_h).not_to include(:disagree_employment)
     end
   end
 
@@ -196,8 +247,6 @@ RSpec.describe ClaimantsDetail, type: :model do
       populated_claimant_detail.agree_with_employment_dates = false
       populated_claimant_detail.employment_end = nil
 
-      populated_claimant_detail.valid?
-
       expect(populated_claimant_detail.errors.details[:employment_end]).to include a_hash_including(error: :blank)
     end
 
@@ -211,12 +260,19 @@ RSpec.describe ClaimantsDetail, type: :model do
     end
   end
 
+  context "when agreeing with description of job or title" do
+    it 'will not hash disagree claimants job or title' do
+      populated_claimant_detail.agree_with_claimants_description_of_job_or_title = true
+      populated_claimant_detail.disagree_claimants_job_or_title = "string that will not be hashed"
+
+      expect(populated_claimant_detail.to_h).not_to include(:disagree_claimants_job_or_title)
+    end
+  end
+
   context "when disagreeing with description of job or title" do
     it 'will not raise a validation error on disagree claimants job or title' do
       populated_claimant_detail.agree_with_claimants_description_of_job_or_title = false
       populated_claimant_detail.disagree_claimants_job_or_title = nil
-
-      populated_claimant_detail.valid?
 
       expect(populated_claimant_detail).to be_valid
     end

--- a/spec/forms/earnings_and_benefits_spec.rb
+++ b/spec/forms/earnings_and_benefits_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe EarningsAndBenefits, type: :model do
     )
   }
 
-  let(:four_hundred_and_one_chars) { Faker::Lorem.characters(451) }
+  let(:four_hundred_and_one_chars) { Faker::Lorem.characters(401) }
 
   let(:three_hundred_fifty_one_chars) { Faker::Lorem.characters(351) }
 
@@ -229,4 +229,136 @@ RSpec.describe EarningsAndBenefits, type: :model do
       expect(populated_earnings_and_benefits).to be_valid
     end
   end
+
+  context "when agreeing with claimants hours of work" do
+    it 'will not validate queried hours' do
+      populated_earnings_and_benefits.agree_with_claimants_hours = true
+      populated_earnings_and_benefits.queried_hours = "a string"
+
+      expect(populated_earnings_and_benefits).to be_valid
+    end
+
+    it 'will not hash queried hours' do
+      populated_earnings_and_benefits.agree_with_claimants_hours = true
+      populated_earnings_and_benefits.queried_hours = "a string"
+
+      expect(populated_earnings_and_benefits.to_h).not_to include(:queried_hours)
+    end
+  end
+
+  context "when disagreeing with claimants hours of work" do
+    it 'will raise a validation error on queried hours' do
+      populated_earnings_and_benefits.agree_with_claimants_hours = false
+      populated_earnings_and_benefits.queried_hours = "a string"
+
+      populated_earnings_and_benefits.valid?
+
+      expect(populated_earnings_and_benefits.errors.details[:queried_hours]).to include a_hash_including(error: :not_a_number)
+    end
+  end
+
+  context "when agreeing with claimants earnings details" do
+    it 'will not validate queried pay before tax' do
+      populated_earnings_and_benefits.agree_with_earnings_details = true
+      populated_earnings_and_benefits.queried_pay_before_tax = "a string"
+
+      expect(populated_earnings_and_benefits).to be_valid
+    end
+
+    it 'will not validate queried take home pay' do
+      populated_earnings_and_benefits.agree_with_earnings_details = true
+      populated_earnings_and_benefits.queried_take_home_pay = "a string"
+
+      expect(populated_earnings_and_benefits).to be_valid
+    end
+
+    it 'will not hash queried pay before tax' do
+      populated_earnings_and_benefits.agree_with_earnings_details = true
+      populated_earnings_and_benefits.queried_pay_before_tax = "a string"
+
+      expect(populated_earnings_and_benefits.to_h).not_to include(:queried_pay_before_tax)
+    end
+
+    it 'will not hash queried take home pay' do
+      populated_earnings_and_benefits.agree_with_earnings_details = true
+      populated_earnings_and_benefits.queried_take_home_pay = "a string"
+
+      expect(populated_earnings_and_benefits.to_h).not_to include(:queried_take_home_pay)
+    end
+  end
+
+  context "when disagreeing with claimants earnings details" do
+    it 'will raise a validation error on queried pay before tax' do
+      populated_earnings_and_benefits.agree_with_earnings_details = false
+      populated_earnings_and_benefits.queried_pay_before_tax = "a string"
+
+      populated_earnings_and_benefits.valid?
+
+      expect(populated_earnings_and_benefits.errors.details[:queried_pay_before_tax]).to include a_hash_including(error: :not_a_number)
+    end
+
+    it 'will raise a validation error on queried take home pay' do
+      populated_earnings_and_benefits.agree_with_earnings_details = false
+      populated_earnings_and_benefits.queried_take_home_pay = "a string"
+
+      populated_earnings_and_benefits.valid?
+
+      expect(populated_earnings_and_benefits.errors.details[:queried_take_home_pay]).to include a_hash_including(error: :not_a_number)
+    end
+  end
+
+  context "when agreeing with claimants notice" do
+    it 'will not validate disagree claimant notice reason' do
+      populated_earnings_and_benefits.agree_with_claimant_notice = true
+      populated_earnings_and_benefits.disagree_claimant_notice_reason = four_hundred_and_one_chars
+
+      expect(populated_earnings_and_benefits).to be_valid
+    end
+
+    it 'will not hash disagree claimant notice reason' do
+      populated_earnings_and_benefits.agree_with_claimant_notice = true
+
+      expect(populated_earnings_and_benefits.to_h).not_to include(:disagree_claimant_notice_reason)
+    end
+  end
+
+  context "when disagreeing with claimants notice" do
+    it 'will raise a validation error on disagree claimant notice reason' do
+      populated_earnings_and_benefits.agree_with_claimants_hours = false
+      populated_earnings_and_benefits.disagree_claimant_notice_reason = four_hundred_and_one_chars
+
+      populated_earnings_and_benefits.valid?
+
+      expect(populated_earnings_and_benefits.errors.details[:disagree_claimant_notice_reason]).to include a_hash_including(error: :too_long)
+    end
+  end
+
+  context "when agreeing with claimant pension benefits" do
+    it 'will not validate disagree claimant pension benefits reason' do
+      populated_earnings_and_benefits.agree_with_claimant_pension_benefits = true
+      populated_earnings_and_benefits.disagree_claimant_pension_benefits_reason = three_hundred_fifty_one_chars
+
+      expect(populated_earnings_and_benefits).to be_valid
+    end
+
+    it 'will not hash disagree claimant pension benefits reason' do
+      populated_earnings_and_benefits.agree_with_claimant_pension_benefits = true
+      populated_earnings_and_benefits.disagree_claimant_pension_benefits_reason = three_hundred_fifty_one_chars
+
+      expect(populated_earnings_and_benefits.to_h).not_to include(:disagree_claimant_pension_benefits_reason)
+    end
+  end
+
+  context "when disagreeing with claimant pension benefits" do
+    it 'will raise a validation error on disagree claimant pension benefits reason' do
+      populated_earnings_and_benefits.agree_with_claimants_hours = false
+      populated_earnings_and_benefits.disagree_claimant_pension_benefits_reason = three_hundred_fifty_one_chars
+
+      populated_earnings_and_benefits.valid?
+
+      expect(populated_earnings_and_benefits.errors.details[:disagree_claimant_pension_benefits_reason]).to include a_hash_including(error: :too_long)
+    end
+  end
+
 end
+

--- a/spec/forms/employers_contract_claim_spec.rb
+++ b/spec/forms/employers_contract_claim_spec.rb
@@ -65,4 +65,30 @@ RSpec.describe EmployersContractClaim, type: :model do
       expect(populated_employers_contract_claim).to be_valid
     end
   end
+
+  context "when making an employer contract claim" do
+    it 'will raise a validation error on claim information' do
+      populated_employers_contract_claim.make_employer_contract_claim = true
+      populated_employers_contract_claim.claim_information = four_thousand_five_hundred_and_one_characters
+
+      populated_employers_contract_claim.valid?
+
+      expect(populated_employers_contract_claim.errors.details[:claim_information]).to include a_hash_including(error: :too_long)
+    end
+  end
+
+  context "when not making an employer contract claim" do
+    it 'will not validate claim information' do
+      populated_employers_contract_claim.make_employer_contract_claim = false
+      populated_employers_contract_claim.claim_information = four_thousand_five_hundred_and_one_characters
+
+      expect(populated_employers_contract_claim).to be_valid
+    end
+
+    it 'will not hash claim information' do
+      populated_employers_contract_claim.make_employer_contract_claim = false
+
+      expect(populated_employers_contract_claim.to_h).not_to include(:claim_information)
+    end
+  end
 end

--- a/spec/forms/respondents_detail_spec.rb
+++ b/spec/forms/respondents_detail_spec.rb
@@ -219,6 +219,8 @@ RSpec.describe RespondentsDetail, type: :model do
     end
 
     it 'will return the fax_number key and value pair' do
+      populated_respondent_detail.contact_preference = "fax"
+
       expect(populated_respondent_detail.to_h).to include(fax_number: '0207 123 4567')
     end
 
@@ -374,6 +376,45 @@ RSpec.describe RespondentsDetail, type: :model do
       expect(populated_respondent_detail).to be_valid
     end
 
+    it "will not validate a fax number" do
+      populated_respondent_detail.contact_preference = "email"
+      populated_respondent_detail.fax_number = "invalid fax"
+
+      expect(populated_respondent_detail).to be_valid
+    end
+
+    it "will not hash a fax number" do
+      populated_respondent_detail.contact_preference = "email"
+      populated_respondent_detail.fax_number = "0203 123 4567"
+
+      expect(populated_respondent_detail.to_h).not_to include(:fax_number)
+    end
+
+  end
+
+  context "when post is the preferred contact method" do
+
+    it "will not validate an email address or fax number" do
+      populated_respondent_detail.contact_preference = "post"
+      populated_respondent_detail.email_address = "invalid email"
+      populated_respondent_detail.fax_number = "invalid fax"
+
+      expect(populated_respondent_detail).to be_valid
+    end
+
+    it "will not hash an email address" do
+      populated_respondent_detail.contact_preference = "post"
+      populated_respondent_detail.email_address = "john@dodgyco.com"
+
+      expect(populated_respondent_detail.to_h).not_to include(:email_address)
+    end
+
+    it "will not hash a fax number" do
+      populated_respondent_detail.contact_preference = "post"
+      populated_respondent_detail.fax_number = "0203 123 4567"
+
+      expect(populated_respondent_detail.to_h).not_to include(:fax_number)
+    end
   end
 
   context "when fax is the preferred contact method" do
@@ -394,6 +435,22 @@ RSpec.describe RespondentsDetail, type: :model do
       expect(populated_respondent_detail).to be_valid
     end
 
+    it "will not validate an email address" do
+      populated_respondent_detail.contact_preference = "fax"
+      populated_respondent_detail.fax_number = "0203 123 4567"
+      populated_respondent_detail.email_address = "invalid email"
+
+      populated_respondent_detail.valid?
+
+      expect(populated_respondent_detail).to be_valid
+    end
+
+    it "will not hash an email address" do
+      populated_respondent_detail.contact_preference = "fax"
+      populated_respondent_detail.email_address = "john@dodgyco.com"
+
+      expect(populated_respondent_detail.to_h).not_to include(:email_address)
+    end
   end
 
   context "when the organisation has more than one site" do
@@ -416,4 +473,23 @@ RSpec.describe RespondentsDetail, type: :model do
 
   end
 
-end
+  context "when the organisation does not have more than one site" do
+    it "will not validate an employment at site number" do
+      populated_respondent_detail.organisation_more_than_one_site = false
+      populated_respondent_detail.employment_at_site_number = "fsdf"
+
+      populated_respondent_detail.valid?
+
+      expect(populated_respondent_detail).to be_valid
+    end
+
+    it "will not hash an employment at site number" do
+      populated_respondent_detail.organisation_more_than_one_site = false
+      populated_respondent_detail.employment_at_site_number = 20
+
+      expect(populated_respondent_detail.to_h).not_to include(:employment_at_site_number)
+    end
+  end
+
+
+  end

--- a/spec/forms/response_spec.rb
+++ b/spec/forms/response_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Response, type: :model do
     )
   }
 
-  let(:two_thousand_five_hundred_and_one_characters) { Faker::Lorem.characters(4501) }
+  let(:two_thousand_five_hundred_and_one_characters) { Faker::Lorem.characters(2501) }
 
   context 'with validators' do
 
@@ -62,6 +62,33 @@ RSpec.describe Response, type: :model do
       populated_response.valid?
 
       expect(populated_response).to be_valid
+    end
+  end
+
+  context "when defending the claim" do
+    it 'will raise a validation error on defend_claim_facts' do
+      populated_response.defend_claim = true
+      populated_response.defend_claim_facts = two_thousand_five_hundred_and_one_characters
+
+      populated_response.valid?
+
+      expect(populated_response.errors.details[:defend_claim_facts]).to include a_hash_including(error: :too_long)
+    end
+  end
+
+  context "when not defending the claim" do
+    it 'will not validate defend claim facts' do
+      populated_response.defend_claim = false
+      populated_response.defend_claim_facts = two_thousand_five_hundred_and_one_characters
+
+      expect(populated_response).to be_valid
+    end
+
+    it 'will not hash defend claim facts' do
+      populated_response.defend_claim = false
+      populated_response.defend_claim_facts = two_thousand_five_hundred_and_one_characters
+
+      expect(populated_response.to_h).not_to include(:defend_claim_facts)
     end
   end
 end

--- a/spec/forms/your_representatives_details_spec.rb
+++ b/spec/forms/your_representatives_details_spec.rb
@@ -205,6 +205,7 @@ RSpec.describe YourRepresentativesDetails, type: :model do
     end
 
     it 'will return the representative_fax key and value pair' do
+      populated_your_representatives_details.representative_contact_preference = "fax"
       expect(populated_your_representatives_details.to_h).to include(representative_fax: '0207 345 6789')
     end
 
@@ -347,6 +348,45 @@ RSpec.describe YourRepresentativesDetails, type: :model do
 
       expect(populated_your_representatives_details).to be_valid
     end
+
+    it 'will not validate a fax number' do
+      populated_your_representatives_details.representative_contact_preference = "email"
+      populated_your_representatives_details.representative_fax = "invalid fax"
+
+      expect(populated_your_representatives_details).to be_valid
+    end
+
+    it 'will not hash a fax number' do
+      populated_your_representatives_details.representative_contact_preference = "email"
+      populated_your_representatives_details.representative_fax = "0203 123 4567"
+
+      expect(populated_your_representatives_details.to_h).not_to include(:representative_fax)
+    end
+  end
+
+  context "when post is the preferred contact method" do
+
+    it "will not validate an email address or fax number" do
+      populated_your_representatives_details.representative_contact_preference = "post"
+      populated_your_representatives_details.representative_email = "invalid email"
+      populated_your_representatives_details.representative_fax = "invalid fax"
+
+      expect(populated_your_representatives_details).to be_valid
+    end
+
+    it "will not hash an email address" do
+      populated_your_representatives_details.representative_contact_preference = "post"
+      populated_your_representatives_details.representative_email = "john@dodgyco.com"
+
+      expect(populated_your_representatives_details.to_h).not_to include(:representative_email)
+    end
+
+    it "will not hash a fax number" do
+      populated_your_representatives_details.representative_contact_preference = "post"
+      populated_your_representatives_details.representative_fax = "0203 123 4567"
+
+      expect(populated_your_representatives_details.to_h).not_to include(:representative_fax)
+    end
   end
 
   context "when fax is the preferred contact method" do
@@ -364,6 +404,20 @@ RSpec.describe YourRepresentativesDetails, type: :model do
       populated_your_representatives_details.representative_fax = "0203 123 4567"
 
       expect(populated_your_representatives_details).to be_valid
+    end
+
+    it "will not validate an email address" do
+      populated_your_representatives_details.representative_contact_preference = "fax"
+      populated_your_representatives_details.representative_email = "invalid email"
+
+      expect(populated_your_representatives_details).to be_valid
+    end
+
+    it "will not hash an email address" do
+      populated_your_representatives_details.representative_contact_preference = "fax"
+      populated_your_representatives_details.representative_email = "john@dodgyco.com"
+
+      expect(populated_your_representatives_details.to_h).not_to include(:representative_email)
     end
   end
 
@@ -384,6 +438,22 @@ RSpec.describe YourRepresentativesDetails, type: :model do
       populated_your_representatives_details.valid?
 
       expect(populated_your_representatives_details).to be_valid
+    end
+  end
+
+  context "when representative does not have a disability" do
+    it 'will not validate representative disability information' do
+      populated_your_representatives_details.representative_disability = false
+      populated_your_representatives_details.representative_disability_information = three_hundred_fifty_one_chars
+
+      expect(populated_your_representatives_details).to be_valid
+    end
+
+    it 'will not hash representative disability information' do
+      populated_your_representatives_details.representative_disability = false
+      populated_your_representatives_details.representative_disability_information = 'Lorem ipsum disability'
+
+      expect(populated_your_representatives_details.to_h).not_to include(:representative_disability_information)
     end
   end
 end


### PR DESCRIPTION
While picking up RST-1261 I noticed that there was a negative flow through the app that was very buggy.

When asking a user for their contact preference they are given a choice of email, post and fax. If they were to select email or fax they would be given the opportunity to enter an email address/fax number.

If they were to select email, enter an address, then change their minds and enter a fax number, the email address would still be submitted to the app.

RST-1261 alerted me to this as I wasn't validating properly so validation errors persisted if a different radio button was selected. However, despite validation being conditional, the submission was not conditional anywhere.

This PR corrects both the submission and validation of conditional data, resolving RST-1261 in the process.