### PR TITLE
Remove dotenv references from boot

### DIFF
--- a/config/boot.rb
+++ b/config/boot.rb
@@ -2,4 +2,3 @@ ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', __dir__)
 
 require 'bundler/setup' # Set up gems listed in the Gemfile.
 require 'bootsnap/setup' # Speed up boot time by caching expensive operations.
-require 'dotenv/load' if ENV['RUBY_ENV'] == "development" || ENV['RUBY_ENV'] == "test" # Use dotenv gem to load .env file variables into environment.

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -2,4 +2,4 @@ ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', __dir__)
 
 require 'bundler/setup' # Set up gems listed in the Gemfile.
 require 'bootsnap/setup' # Speed up boot time by caching expensive operations.
-require 'dotenv/load' # Use dotenv gem to load .env file variables into environment.
+require 'dotenv/load' if ENV['RUBY_ENV'] == "development" || ENV['RUBY_ENV'] == "test" # Use dotenv gem to load .env file variables into environment.


### PR DESCRIPTION
Current configuration is incorrect and will lead to production environments still searching for a `.env` file, this change removes the application dependency.