### PR TITLE
Hotfix RST-1160: Remove Representative Disability References

### DIFF
--- a/app/controllers/your_representatives_details_controller.rb
+++ b/app/controllers/your_representatives_details_controller.rb
@@ -20,6 +20,6 @@ class YourRepresentativesDetailsController < ApplicationController
       :representative_org_name, :representative_name, :representative_building, :representative_street,
       :representative_town, :representative_county, :representative_postcode, :representative_phone,
       :representative_mobile, :representative_dx_number, :representative_reference, :representative_contact_preference,
-      :representative_email, :representative_fax, :representative_disability, :representative_disability_information)
+      :representative_email, :representative_fax)
   end
 end

--- a/app/forms/your_representatives_details.rb
+++ b/app/forms/your_representatives_details.rb
@@ -14,8 +14,6 @@ class YourRepresentativesDetails < BaseForm
   attribute :representative_contact_preference, :string
   attribute :representative_email, :string
   attribute :representative_fax, :string
-  attribute :representative_disability, :boolean
-  attribute :representative_disability_information, :text
 
   def to_h # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
     representatives_detail_hash = {
@@ -73,13 +71,6 @@ class YourRepresentativesDetails < BaseForm
   validates :representative_fax,
     phone_number: true,
     if: :prefer_fax?
-  validates :representative_disability_information,
-    length: {
-      maximum: 350,
-      too_long: "%{count} characters is the maximum allowed" # rubocop:disable Style/FormatStringToken
-    },
-    presence: true,
-    if: :representative_is_disabled?
 
   private
 
@@ -89,9 +80,5 @@ class YourRepresentativesDetails < BaseForm
 
   def prefer_fax?
     representative_contact_preference == "fax"
-  end
-
-  def representative_is_disabled?
-    representative_disability
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -223,8 +223,8 @@ en:
           PLEASE NOTE – You will only be able to enter a limited amount of information here (up to 2500 characters) if you would like to include more please
           use our upload facility at the end of this form where you will be able to upload a Rich Text Format (.rtf) file.
           If you exceed 25 lines you will not receive full details of your response in the PDF returned to you on submission of the form.
-      your_representatives_details:
-        representative_disability_information: |
+      disability:
+        disability_information: |
           PLEASE NOTE – You will only be able to enter a limited amount of information here (up to 350 characters) if you would like to include more please
           use our upload facility at the end of this form where you will be able to upload a Rich Text Format (.rtf) file.
       employers_contract_claim:

--- a/test_common/fixtures/personas.yml
+++ b/test_common/fixtures/personas.yml
@@ -194,8 +194,9 @@ erroneously_entering_data_on_confirmation_of_supplied_details_page:
   representative_reference: 'Rep Ref'
   representative_contact_preference: 'Fax'
   representative_fax: '0207 345 6789'
-  representative_disability: 'Yes'
-  representative_disability_information: 'Lorem ipsum disability'
+  # Disability
+  disability: 'Yes'
+  disability_information: 'Lorem ipsum disability'
   # Employers Contract Claim
   make_employer_contract_claim: 'Yes'
   claim_information: 'lorem ipsum info'


### PR DESCRIPTION
I forgot to remove references to the `representative_disability` attribute. It had no impact on the code but always best to keep the codebase tidy.