### PR TITLE
RST-1360: Move Disability into BuildRespondent

### DIFF
--- a/app/services/et_api_handler.rb
+++ b/app/services/et_api_handler.rb
@@ -6,7 +6,6 @@ class EtApiHandler
 
     data_array = [build_response_data(form_hash), build_respondent_data(form_hash)]
     data_array.push(build_representative_data(form_hash)) if form_hash[:your_representative_answers][:have_representative]
-    data_array[1][:data].merge!(build_disability_data(form_hash)) if form_hash[:disability_answers][:disability]
 
     http_response = HTTParty.post("#{ENV.fetch('ET_API_URL', 'http://api.et.127.0.0.1.nip.io:3100/api')}/v2/respondents/build_response",
       body: {
@@ -59,7 +58,7 @@ class EtApiHandler
   end
 
   def self.build_respondent_data(full_hash)
-    {
+    respondent_hash = {
       "command": "BuildRespondent",
       "data": {
         "name": full_hash[:respondents_detail_answers][:name],
@@ -83,6 +82,9 @@ class EtApiHandler
       },
       "uuid": SecureRandom.uuid
     }
+
+    respondent_hash[:data] = respondent_hash[:data].merge(build_disability_data(full_hash)) if full_hash[:disability_answers][:disability]
+    respondent_hash
   end
 
   def self.build_representative_data(full_hash)

--- a/app/services/et_api_handler.rb
+++ b/app/services/et_api_handler.rb
@@ -6,6 +6,7 @@ class EtApiHandler
 
     data_array = [build_response_data(form_hash), build_respondent_data(form_hash)]
     data_array.push(build_representative_data(form_hash)) if form_hash[:your_representative_answers][:have_representative]
+    data_array[1][:data].merge!(build_disability_data(form_hash)) if form_hash[:disability_answers][:disability]
 
     http_response = HTTParty.post("#{ENV.fetch('ET_API_URL', 'http://api.et.127.0.0.1.nip.io:3100/api')}/v2/respondents/build_response",
       body: {
@@ -104,11 +105,16 @@ class EtApiHandler
         "reference": full_hash[:your_representatives_details_answers][:representative_reference],
         "contact_preference": full_hash[:your_representatives_details_answers][:representative_contact_preference],
         "email_address": full_hash[:your_representatives_details_answers][:representative_email],
-        "fax_number": full_hash[:your_representatives_details_answers][:representative_fax],
-        "disability": full_hash[:disability_answers][:disability],
-        "disability_information": full_hash[:disability_answers][:disability_information]
+        "fax_number": full_hash[:your_representatives_details_answers][:representative_fax]
       },
       "uuid": SecureRandom.uuid
+    }
+  end
+
+  def self.build_disability_data(full_hash)
+    {
+      "disability": full_hash[:disability_answers][:disability],
+      "disability_information": full_hash[:disability_answers][:disability_information]
     }
   end
 end

--- a/spec/features/fill_in_whole_form_spec.rb
+++ b/spec/features/fill_in_whole_form_spec.rb
@@ -177,6 +177,8 @@ RSpec.feature "Fill in whole form", js: true do
           expect(request_body["data"][1]["data"]["organisation_employ_gb"]).to eql user_data.organisation_employ_gb
           expect(request_body["data"][1]["data"]["organisation_more_than_one_site"]).to eql(user_data.organisation_more_than_one_site == 'Yes')
           expect(request_body["data"][1]["data"]["employment_at_site_number"]).to eql user_data.employment_at_site_number
+          expect(request_body["data"][1]["data"]["disability"]).to eql(user_data.disability == 'Yes')
+          expect(request_body["data"][1]["data"]["disability_information"]).to eql user_data.disability_information
           expect(request_body["data"][1]["uuid"]).to be_an_instance_of(String)
           expect(request_body["data"][2]["command"]).to eql "BuildRepresentative"
           expect(request_body["data"][2]["data"]["name"]).to eql user_data.representative_name
@@ -194,8 +196,6 @@ RSpec.feature "Fill in whole form", js: true do
           expect(request_body["data"][2]["data"]["contact_preference"].capitalize).to eql user_data.representative_contact_preference
           expect(request_body["data"][2]["data"]["email_address"]).to eql user_data.representative_email if user_data.representative_contact_preference == "email"
           expect(request_body["data"][2]["data"]["fax_number"]).to eql user_data.representative_fax if user_data.representative_contact_preference == "fax"
-          expect(request_body["data"][2]["data"]["disability"]).to eql(user_data.disability == 'Yes')
-          expect(request_body["data"][2]["data"]["disability_information"]).to eql user_data.disability_information
           expect(request_body["data"][2]["uuid"]).to be_an_instance_of(String)
           expect(request.headers).to include("Content-Type" => "application/json", "Accept" => "application/json")
         }).to have_been_made.once

--- a/test_common/helpers/setup.rb
+++ b/test_common/helpers/setup.rb
@@ -167,7 +167,6 @@ module ET3
       end
 
       # Disability Page
-
       def answer_disability_question
         disability_page.disability_question.set_for(user)
       end


### PR DESCRIPTION
### This is a breaking change in the API and ministryofjustice/et_api/pull/86 must be released at the same time

This PR moves `disability` and `disability_information` into the `"BuildRespondent"` section of the submission hash, away from `"BuildRepresentative"`.