### PR TITLE
RST-1381: Fix remove file link

### DIFF
--- a/app/assets/javascripts/uploadAdditionalInformation.js
+++ b/app/assets/javascripts/uploadAdditionalInformation.js
@@ -96,4 +96,8 @@ $(document).ready(function(){
         // Build a proper warning system for "too many files" warning.
         alert("too many files");
     });
+
+    uploadAdditionalInfoDropzone.on("removedfile", function() {
+        $("#additional_information_upload_file_name").val(null);
+    });
 });

--- a/app/helpers/uploaded_file_name_helper.rb
+++ b/app/helpers/uploaded_file_name_helper.rb
@@ -1,0 +1,9 @@
+module UploadedFileNameHelper
+  def uploaded_file_name
+    if @hash_store[:additional_information_answers].key?(:upload_file_name) &&
+        !@hash_store.dig(:additional_information_answers, :upload_file_name).empty?
+
+      @hash_store[:additional_information_answers][:upload_file_name]
+    end
+  end
+end

--- a/app/helpers/uploaded_file_name_helper.rb
+++ b/app/helpers/uploaded_file_name_helper.rb
@@ -1,9 +1,8 @@
 module UploadedFileNameHelper
   def uploaded_file_name
-    if @hash_store[:additional_information_answers].key?(:upload_file_name) &&
-        !@hash_store.dig(:additional_information_answers, :upload_file_name).empty?
-
-      @hash_store[:additional_information_answers][:upload_file_name]
+    if @hash_store.dig(:additional_information_answers, :upload_file_name)
+      @hash_store[:additional_information_answers][:upload_file_name] unless
+        @hash_store.dig(:additional_information_answers, :upload_file_name).empty?
     end
   end
 end

--- a/app/views/confirmation_of_supplied_details/edit.html.slim
+++ b/app/views/confirmation_of_supplied_details/edit.html.slim
@@ -300,7 +300,7 @@
         tr
           td = t('helpers.label.additional_information.upload_additional_information')
           td
-            = @hash_store[:additional_information_answers][:upload_file_name]
+            = @hash_store.dig(:additional_information_answers, :upload_file_name)
             - if uploaded_file_name
               br
               = link_to t('components.confirmation_of_supplied_details.remove_file_link'), remove_rtf_path, method: :delete

--- a/app/views/confirmation_of_supplied_details/edit.html.slim
+++ b/app/views/confirmation_of_supplied_details/edit.html.slim
@@ -300,10 +300,10 @@
         tr
           td = t('helpers.label.additional_information.upload_additional_information')
           td
-            - if @hash_store.dig(:additional_information_answers, :upload_file_name)
-              = @hash_store[:additional_information_answers][:upload_file_name]
+            = @hash_store[:additional_information_answers][:upload_file_name]
+            - if uploaded_file_name
               br
-              = link_to 'Remove file', remove_rtf_path, method: :delete
+              = link_to t('components.confirmation_of_supplied_details.remove_file_link'), remove_rtf_path, method: :delete
         tr
           td
             = link_to("Edit answers on this page", edit_additional_information_path)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -292,3 +292,5 @@ en:
       download_href: https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/719457/et3-eng.pdf
       more_category_link: More from the Working, jobs and pensions category
       more_category_href: http://gov.uk/browse/working
+    confirmation_of_supplied_details:
+      remove_file_link: Remove file

--- a/spec/features/fill_in_additional_information_page_spec.rb
+++ b/spec/features/fill_in_additional_information_page_spec.rb
@@ -1,5 +1,6 @@
 require 'rails_helper'
 RSpec.feature "Fill in Additional Information Page", js: true do
+  include ET3::Test::I18n
   let(:confirmation_of_supplied_details_page) { ET3::Test::ConfirmationOfSuppliedDetailsPage.new }
 
   before do
@@ -21,5 +22,12 @@ RSpec.feature "Fill in Additional Information Page", js: true do
   scenario "incorrectly will provide errors" do
     pending("while we wait for a test environment to understand how the s3 bucket timings will work")
     fail
+  end
+
+  scenario "without uploading a file will not display 'Remove file' link on CoSD page" do
+    additional_information_page.load
+    additional_information_page.next
+
+    expect(confirmation_of_supplied_details_page.confirmation_of_additional_information_answers).not_to have_link(t('components.confirmation_of_supplied_details.remove_file_link'), href: remove_rtf_path)
   end
 end

--- a/test_common/messaging/en.yml
+++ b/test_common/messaging/en.yml
@@ -295,3 +295,5 @@ en:
       download_href: https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/719457/et3-eng.pdf
       more_category_link: More from the Working, jobs and pensions category
       more_category_href: http://gov.uk/browse/working
+    confirmation_of_supplied_details:
+      remove_file_link: Remove file


### PR DESCRIPTION
On the 'Confirmation of Supplied Details' page there is a link to remove an uploaded file. This link should only render if a file has been uploaded. However, it currently renders any time the `:additional_information_answers` hash is populated with a key for `:upload_additional_information`, even though this is populated by default with an empty string.

This PR fixes that issue by checking if the string is empty. The logic is in a helper to keep the code clean and there is an accompanying spec.