### PR TITLE
Prepare v2.1.0

### DIFF
--- a/app/assets/javascripts/disablePdfLink.js
+++ b/app/assets/javascripts/disablePdfLink.js
@@ -1,0 +1,20 @@
+$( document ).on('turbolinks:load', function() {
+    checkLinkStatus();
+});
+
+function checkLinkStatus() {
+    let pdfUrl = $('.download-pdf').attr('href');
+    $.ajax({
+        url: pdfUrl,
+        success: function() {
+            $('.download-pdf').text('A PDF version of your completed form is now available for download')
+                .css('pointer-events', 'auto');
+        },
+        error: function() {
+            $('.download-pdf').text('Not quite ready yet - a PDF version of your completed form will be available for download shortly')
+                .css('pointer-events', 'none');
+            console.warn(`Unable to find PDF, retrying ${pdfUrl} 10 seconds`);
+            setTimeout(checkLinkStatus, 10000);
+        }
+    })
+}

--- a/app/assets/javascripts/uploadAdditionalInformation.js
+++ b/app/assets/javascripts/uploadAdditionalInformation.js
@@ -1,103 +1,105 @@
 $(document).ready(function(){
     Dropzone.autoDiscover = false;
 
-    // Source:
-    // stackoverflow.com/questions/105034/create-guid-uuid-in-javascript#answer-2117523
-    function uuidv4() {
-        return ([1e7]+-1e3+-4e3+-8e3+-1e11).replace(/[018]/g, (c) =>
-            (c ^ crypto.getRandomValues(new Uint8Array(1))[0] & 15 >> c / 4).toString(16)
-        )
-    }
+    if ($("#upload-additional-file").length) {
+        // Source:
+        // stackoverflow.com/questions/105034/create-guid-uuid-in-javascript#answer-2117523
+        function uuidv4() {
+            return ([1e7] + -1e3 + -4e3 + -8e3 + -1e11).replace(/[018]/g, (c) =>
+                (c ^ crypto.getRandomValues(new Uint8Array(1))[0] & 15 >> c / 4).toString(16)
+            )
+        }
 
-    function setUploadUrl(url) {
-        uploadAdditionalInfoDropzone.options.url = url;
-    }
+        function setUploadUrl(url) {
+            uploadAdditionalInfoDropzone.options.url = url;
+        }
 
-    function prepareAwsHiddenInputs(responseData) {
-        $("#aws_key").attr("name", "key").val(responseData.fields["key"]);
-        $("#aws_policy").attr("name", "policy").val(responseData.fields["policy"]);
-        $("#aws_x-amz-algorithm").attr("name", "x-amz-algorithm").val(responseData.fields["x-amz-algorithm"]);
-        $("#aws_x-amz-credential").attr("name", "x-amz-credential").val(responseData.fields["x-amz-credential"]);
-        $("#aws_x-amz-date").attr("name", "x-amz-date").val(responseData.fields["x-amz-date"]);
-        $("#aws_x-amz-signature").attr("name", "x-amz-signature").val(responseData.fields["x-amz-signature"]);
-        $("#aws_success_action_status").attr("name", "success_action_status").val(responseData.fields["success_action_status"]);
-    }
+        function prepareAwsHiddenInputs(responseData) {
+            $("#aws_key").attr("name", "key").val(responseData.fields["key"]);
+            $("#aws_policy").attr("name", "policy").val(responseData.fields["policy"]);
+            $("#aws_x-amz-algorithm").attr("name", "x-amz-algorithm").val(responseData.fields["x-amz-algorithm"]);
+            $("#aws_x-amz-credential").attr("name", "x-amz-credential").val(responseData.fields["x-amz-credential"]);
+            $("#aws_x-amz-date").attr("name", "x-amz-date").val(responseData.fields["x-amz-date"]);
+            $("#aws_x-amz-signature").attr("name", "x-amz-signature").val(responseData.fields["x-amz-signature"]);
+            $("#aws_success_action_status").attr("name", "success_action_status").val(responseData.fields["success_action_status"]);
+        }
 
-    function getPresignedS3Url (cb) {
-        $.ajax({
-            url: "/api/s3/create_signed_url",
-            dataType: "json",
-            data: {
+        function getPresignedS3Url(cb) {
+            $.ajax({
+                url: "/api/s3/create_signed_url",
+                dataType: "json",
+                data: {
                     uuid: uuidv4(),
                     command: "CreateSignedS3FormData",
                     async: false,
                     data: {
                         preventEmptyData: true
                     }
-            },
-            error: onGetPresignedError,
-            method: "post",
-            success: function (data, status, xhr) {
-                cb.apply(this, [data.data]);
+                },
+                error: onGetPresignedError,
+                method: "post",
+                success: function (data, status, xhr) {
+                    cb.apply(this, [data.data]);
+                }
+            });
+        }
+
+        function onGetPresignedError(xhr, status, error) {
+            /* TODO: RST-1220:
+                Anticipate and handle errors:
+                - Network issue to API (no response)
+                - Network issue to/from S3 (API responds with bad data)
+            */
+        }
+
+        function removeButtonElement(button) {
+            return button.detach();
+        }
+
+        function appendButtonElement(button) {
+            $(".dz-default.dz-message.grid-row .column-one-half").append(button);
+        }
+
+        var removedButton;
+
+        let uploadAdditionalInfoDropzone = new Dropzone("#upload-additional-file",
+            {
+                // Only one file goes to the bucket via the URL
+                parallelUploads: 1,
+                uploadMultiple: false,
+                // Set acceptance criteria, one .rtf file
+                maxFiles: 1,
+                acceptedFiles: ".rtf",
+                // If file passes the accept check, call the API and use the returned values for the upload process
+                accept: function (file, done) {
+                    getPresignedS3Url(function (presignedData) {
+                        prepareAwsHiddenInputs(presignedData);
+                        setUploadUrl(presignedData.url);
+                        removedButton = removeButtonElement($("#upload-button"));
+                        done();
+                    });
+                },
+                // Use POST
+                method: "post",
+                // Add a link to remove files that were erroneously uploaded
+                addRemoveLinks: true,
+                success: function (file, response) {
+                    appendButtonElement(removedButton);
+                    // Take upload URL and pass it into the second form
+                    $("#additional_information_upload_additional_information").val($.parseXML(response).getElementsByTagName("Key")[0].childNodes[0].nodeValue);
+                    $("#additional_information_upload_file_name").val(file.name);
+                }
             }
+        );
+
+        uploadAdditionalInfoDropzone.on("maxfilesexceeded", function (file) {
+            // TODO: RST-1220 - Error Handling:
+            // Build a proper warning system for "too many files" warning.
+            alert("too many files");
+        });
+
+        uploadAdditionalInfoDropzone.on("removedfile", function () {
+            $("#additional_information_upload_file_name").val(null);
         });
     }
-
-    function onGetPresignedError(xhr, status, error) {
-        /* TODO: RST-1220:
-            Anticipate and handle errors:
-            - Network issue to API (no response)
-            - Network issue to/from S3 (API responds with bad data)
-        */
-    }
-
-    function removeButtonElement(button) {
-        return button.detach();
-    }
-
-    function appendButtonElement(button) {
-        $(".dz-default.dz-message.grid-row .column-one-half").append(button);
-    }
-
-    var removedButton;
-
-    let uploadAdditionalInfoDropzone = new Dropzone("#upload-additional-file",
-        {
-            // Only one file goes to the bucket via the URL
-            parallelUploads: 1,
-            uploadMultiple: false,
-            // Set acceptance criteria, one .rtf file
-            maxFiles: 1,
-            acceptedFiles: ".rtf",
-            // If file passes the accept check, call the API and use the returned values for the upload process
-            accept: function(file, done) {
-                getPresignedS3Url(function(presignedData) {
-                    prepareAwsHiddenInputs(presignedData);
-                    setUploadUrl(presignedData.url);
-                    removedButton = removeButtonElement($("#upload-button"));
-                    done();
-                });
-            },
-            // Use POST
-            method: "post",
-            // Add a link to remove files that were erroneously uploaded
-            addRemoveLinks: true,
-            success: function(file, response){
-                appendButtonElement(removedButton);
-                // Take upload URL and pass it into the second form
-                $("#additional_information_upload_additional_information").val($.parseXML(response).getElementsByTagName("Key")[0].childNodes[0].nodeValue);
-                $("#additional_information_upload_file_name").val(file.name);
-            }
-        }
-    );
-
-    uploadAdditionalInfoDropzone.on("maxfilesexceeded", function(file) {
-        // TODO: RST-1220 - Error Handling:
-        // Build a proper warning system for "too many files" warning.
-        alert("too many files");
-    });
-
-    uploadAdditionalInfoDropzone.on("removedfile", function() {
-        $("#additional_information_upload_file_name").val(null);
-    });
 });

--- a/app/assets/javascripts/uploadAdditionalInformation.js
+++ b/app/assets/javascripts/uploadAdditionalInformation.js
@@ -96,4 +96,8 @@ $(document).ready(function(){
         // Build a proper warning system for "too many files" warning.
         alert("too many files");
     });
+
+    uploadAdditionalInfoDropzone.on("removedfile", function() {
+        $("#additional_information_upload_file_name").val(null);
+    });
 });

--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -1,6 +1,4 @@
 class StaticPagesController < ApplicationController
-  skip_before_action :check_session_expiry
-
   def index; end
 
   def expired; end

--- a/app/helpers/uploaded_file_name_helper.rb
+++ b/app/helpers/uploaded_file_name_helper.rb
@@ -1,0 +1,8 @@
+module UploadedFileNameHelper
+  def uploaded_file_name
+    if @hash_store.dig(:additional_information_answers, :upload_file_name)
+      @hash_store[:additional_information_answers][:upload_file_name] unless
+        @hash_store.dig(:additional_information_answers, :upload_file_name).empty?
+    end
+  end
+end

--- a/app/views/confirmation_of_supplied_details/edit.html.slim
+++ b/app/views/confirmation_of_supplied_details/edit.html.slim
@@ -300,10 +300,10 @@
         tr
           td = t('helpers.label.additional_information.upload_additional_information')
           td
-            - if @hash_store.dig(:additional_information_answers, :upload_file_name)
-              = @hash_store[:additional_information_answers][:upload_file_name]
+            = @hash_store.dig(:additional_information_answers, :upload_file_name)
+            - if uploaded_file_name
               br
-              = link_to 'Remove file', remove_rtf_path, method: :delete
+              = link_to t('components.confirmation_of_supplied_details.remove_file_link'), remove_rtf_path, method: :delete
         tr
           td
             = link_to("Edit answers on this page", edit_additional_information_path)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -292,3 +292,5 @@ en:
       download_href: https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/719457/et3-eng.pdf
       more_category_link: More from the Working, jobs and pensions category
       more_category_href: http://gov.uk/browse/working
+    confirmation_of_supplied_details:
+      remove_file_link: Remove file

--- a/spec/features/access_form_submission_page_spec.rb
+++ b/spec/features/access_form_submission_page_spec.rb
@@ -16,7 +16,7 @@ RSpec.feature "Access Form Submission Page", js: true do
 
     expect(form_submission_page).to have_submission_confirmation
     expect(form_submission_page).to have_reference_number
-    expect(form_submission_page).to have_download_pdf
+    expect(form_submission_page).to have_valid_pdf_download
   end
 
   scenario "user can navigate to the gov.uk homepage" do

--- a/spec/features/check_for_javascript_browser_errors_spec.rb
+++ b/spec/features/check_for_javascript_browser_errors_spec.rb
@@ -1,0 +1,80 @@
+require 'rails_helper'
+
+RSpec.feature "Check for Javascript Browser Errors", js: true, driver: :chromedriver do
+  include ET3::Test::I18n
+
+  scenario "on start page" do
+    start_page.load
+
+    expect(start_page.js_severe_errors).to be_empty
+  end
+
+  scenario "on respondent's details page" do
+    respondents_details_page.load
+
+    expect(respondents_details_page.js_severe_errors).to be_empty
+  end
+
+  scenario "on claimant's details page" do
+    claimants_details_page.load
+
+    expect(claimants_details_page.js_severe_errors).to be_empty
+  end
+
+  scenario "on earnings and benefits page" do
+    earnings_and_benefits_page.load
+
+    expect(earnings_and_benefits_page.js_severe_errors).to be_empty
+  end
+
+  scenario "response page" do
+    response_page.load
+
+    expect(response_page.js_severe_errors).to be_empty
+  end
+
+  scenario "your representative page" do
+    your_representative_page.load
+
+    expect(your_representative_page.js_severe_errors).to be_empty
+  end
+
+  scenario "your representative's details page" do
+    your_representatives_details_page.load
+
+    expect(your_representatives_details_page.js_severe_errors).to be_empty
+  end
+
+  scenario "disability page" do
+    disability_page.load
+
+    expect(disability_page.js_severe_errors).to be_empty
+  end
+
+  scenario "employer contract claim page" do
+    employers_contract_claim_page.load
+
+    expect(employers_contract_claim_page.js_severe_errors).to be_empty
+  end
+
+  scenario "additional information page" do
+    additional_information_page.load
+
+    expect(additional_information_page.js_severe_errors).to be_empty
+  end
+
+  scenario "confirmation of supplied details page" do
+    confirmation_of_supplied_details_page.load
+
+    expect(confirmation_of_supplied_details_page.js_severe_errors).to be_empty
+  end
+
+  scenario "form submission page" do
+    given_i_am(:company01)
+    answer_all_questions
+    confirmation_of_supplied_details_page.submit_form
+
+    expect(form_submission_page.js_severe_errors).to be_empty
+  end
+
+end

--- a/spec/features/check_pdf_download_link_spec.rb
+++ b/spec/features/check_pdf_download_link_spec.rb
@@ -1,0 +1,62 @@
+require 'rails_helper'
+
+RSpec.feature "Check PDF Download Link", js: true do
+
+  # Upon ET3 submission to API, the API generates a PDF version of the ET3 form it just received.
+  # In the API's response to ET3's submission, it returns a URL for this PDF. However, due to
+  # the asynchronous nature of the PDF generation and API response, the file may not be ready
+  # by the time an ET3 user sees the form submission page.
+  #
+  # As such, upon the form submission page loading, ET3 has a javascript function which checks
+  # whether the PDF link is valid. If it is invalid, it disables the link and changes the text
+  # displayed to the user. It will then check the link every 10 seconds until the link is
+  # valid.
+  #
+  # This spec test this functionality, therefore it uses a special stub which returns a pdf
+  # URL of '/test/pdf-download'. This utilises the controller below to return an invalid
+  # link the first time of asking and a valid one thereafter.
+
+  class PdfDownloadLinkController < ActionController::Base
+    def show
+      session[:hit_count] ||= 0
+      if session[:hit_count] > 0
+        logger.debug 'Session count > 0'
+        head :ok
+      else
+        logger.debug 'Session count =< 0'
+        head :not_found
+      end
+      session[:hit_count] += 1
+    end
+  end
+
+  before do
+    Rails.application.routes.append do
+      get 'test/pdf-download' => 'pdf_download_link#show'
+    end
+    Rails.application.reload_routes!
+  end
+
+  before do
+    stub_submission_with_custom_pdf_download_link
+    stub_presigned_url_api_for_s3
+  end
+
+  scenario "link will be disabled as first request will not be valid" do
+    given_i_am(:company01)
+    answer_all_questions
+    confirmation_of_supplied_details_page.submit_form
+
+    expect(form_submission_page).to have_invalid_pdf_download
+  end
+
+  scenario "link will be enabled as second request will be valid" do
+    given_i_am(:company01)
+    answer_all_questions
+    confirmation_of_supplied_details_page.submit_form
+
+    expect(form_submission_page).to have_invalid_pdf_download
+    expect(form_submission_page).to have_valid_pdf_download
+  end
+
+end

--- a/spec/features/fill_in_additional_information_page_spec.rb
+++ b/spec/features/fill_in_additional_information_page_spec.rb
@@ -1,5 +1,6 @@
 require 'rails_helper'
 RSpec.feature "Fill in Additional Information Page", js: true do
+  include ET3::Test::I18n
   let(:confirmation_of_supplied_details_page) { ET3::Test::ConfirmationOfSuppliedDetailsPage.new }
 
   before do
@@ -21,5 +22,12 @@ RSpec.feature "Fill in Additional Information Page", js: true do
   scenario "incorrectly will provide errors" do
     pending("while we wait for a test environment to understand how the s3 bucket timings will work")
     fail
+  end
+
+  scenario "without uploading a file will not display 'Remove file' link on CoSD page" do
+    additional_information_page.load
+    additional_information_page.next
+
+    expect(confirmation_of_supplied_details_page.confirmation_of_additional_information_answers).not_to have_link(t('components.confirmation_of_supplied_details.remove_file_link'), href: remove_rtf_path)
   end
 end

--- a/spec/features/fill_in_whole_form_spec.rb
+++ b/spec/features/fill_in_whole_form_spec.rb
@@ -204,7 +204,7 @@ RSpec.feature "Fill in whole form", js: true do
     expect(form_submission_page).to have_submission_confirmation
     expect(form_submission_page.reference_number).to have_text "142000000100"
     expect(form_submission_page.submission_date).to have_text "13/01/2018 14:00"
-    expect(form_submission_page).to have_download_pdf
+    expect(form_submission_page).to have_valid_pdf_download
 
   end
 

--- a/test_common/capybara/capybara_driver_helper.rb
+++ b/test_common/capybara/capybara_driver_helper.rb
@@ -48,3 +48,5 @@ Capybara.always_include_port = true
 Capybara.app_host = ENV.fetch('CAPYBARA_APP_HOST', "http://#{ENV.fetch('HOSTNAME', 'localhost')}")
 Capybara.server_host = ENV.fetch('CAPYBARA_SERVER_HOST', ENV.fetch('HOSTNAME', 'localhost'))
 Capybara.server_port = ENV.fetch('CAPYBARA_SERVER_PORT') if ENV.key?('CAPYBARA_SERVER_PORT')
+
+SitePrism.use_implicit_waits = true

--- a/test_common/helpers/pages.rb
+++ b/test_common/helpers/pages.rb
@@ -1,6 +1,10 @@
 module ET3
   module Test
     module Pages
+      def base_page
+        ET3::Test::BasePage.new
+      end
+
       def start_page
         ET3::Test::StartPage.new
       end

--- a/test_common/helpers/setup.rb
+++ b/test_common/helpers/setup.rb
@@ -274,7 +274,29 @@ module ET3
                   "BuildResponse": {
                     "reference": "142000000100",
                     "submitted_at": "2018-01-13 14:00",
-                    "pdf_url": "s3/link/to/form.pdf",
+                    "pdf_url": "http://#{Capybara.current_session.server.host}:#{Capybara.current_session.server.port}/",
+                    "office_address": "Alexandra House, 14-22 The Parsonage, Manchester, M3 2JA",
+                    "office_phone_number": "0161 833 6100"
+                  }
+                }
+              }.to_json,
+            status: 202
+          )
+      end
+
+      # Stub Submission Calls to API using Rack mounted PDF Download URL
+      def stub_submission_with_custom_pdf_download_link # rubocop:disable Metrics/MethodLength
+        stub_request(:post, "#{ENV.fetch('ET_API_URL', 'http://api.et.127.0.0.1.nip.io:3100/api')}/v2/respondents/build_response").
+          with(headers: { 'Content-Type': 'application/json', 'Accept': 'application/json' }).
+          to_return(
+            headers: { 'Content-Type': 'application/json' },
+            body:
+              {
+                "meta": {
+                  "BuildResponse": {
+                    "reference": "142000000100",
+                    "submitted_at": "2018-01-13 14:00",
+                    "pdf_url": "http://#{Capybara.current_session.server.host}:#{Capybara.current_session.server.port}/test/pdf-download",
                     "office_address": "Alexandra House, 14-22 The Parsonage, Manchester, M3 2JA",
                     "office_phone_number": "0161 833 6100"
                   }

--- a/test_common/messaging/en.yml
+++ b/test_common/messaging/en.yml
@@ -295,3 +295,5 @@ en:
       download_href: https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/719457/et3-eng.pdf
       more_category_link: More from the Working, jobs and pensions category
       more_category_href: http://gov.uk/browse/working
+    confirmation_of_supplied_details:
+      remove_file_link: Remove file

--- a/test_common/messaging/en.yml
+++ b/test_common/messaging/en.yml
@@ -279,6 +279,9 @@ en:
   links:
     confirmation_of_supplied_details:
       edit_page: Edit answers on this page
+    form_submission:
+      invalid_pdf_download: Not quite ready yet - a PDF version of your completed form will be available for download shortly
+      valid_pdf_download: A PDF version of your completed form is now available for download
   components:
     single_choice_option_section:
       'yes': "Yes"

--- a/test_common/page_objects/base_page.rb
+++ b/test_common/page_objects/base_page.rb
@@ -15,6 +15,14 @@ module ET3
         element :more_category_link, :link_named, 'components.sidebar.more_category_link'
       end
 
+      def js_severe_errors
+        return [] unless page.driver.try(:browser).try(:browser) == :chromedriver
+        errors = page.driver.browser.manage.logs.get(:browser).select { |error| error.level == "SEVERE" }
+        errors.map do |error|
+          { message: error.message }
+        end
+      end
+
     end
   end
 end

--- a/test_common/page_objects/form_submission_page.rb
+++ b/test_common/page_objects/form_submission_page.rb
@@ -10,7 +10,9 @@ module ET3
 
       element :submission_date, :css, '.submission-date'
 
-      element :download_pdf, :css, '.download-pdf'
+      element :valid_pdf_download, :link_named, 'links.form_submission.valid_pdf_download'
+
+      element :invalid_pdf_download, :link_named, 'links.form_submission.invalid_pdf_download'
 
       element :return_to_govuk_button, :css, 'a.button.button-start'
       def return

--- a/test_common/page_objects/start_page.rb
+++ b/test_common/page_objects/start_page.rb
@@ -11,7 +11,7 @@ module ET3
 
       def next
         start_button.click
-      end      
+      end
     end
   end
 end


### PR DESCRIPTION
# New

* Upon ET3 submission, if the generated PDF download is not ready yet, the link is disabled and the user is made aware that the file will be available shortly as opposed to getting a 404 error. (RST-1402: #100)

# Fixed

* Fix "Remove File" link to prevent it from showing when no file has been uploaded (RST-1381: #94)
* Fix JavaScript error caused by Dropzone being unable to find the uploader element. (RST-1397: #98)
* Prevent sessions being renewed when accessing the landing page after a period of over an hour away from the keyboard.

# Changed