### PR TITLE
Prepare v2.1.1

### DIFF
--- a/app/assets/javascripts/disablePdfLink.js
+++ b/app/assets/javascripts/disablePdfLink.js
@@ -1,20 +1,26 @@
 $( document ).on('turbolinks:load', function() {
-    checkLinkStatus();
+    if ($('.download-pdf').length) {
+        checkLinkStatus();
+    }
 });
 
 function checkLinkStatus() {
-    let pdfUrl = $('.download-pdf').attr('href');
-    $.ajax({
-        url: pdfUrl,
-        success: function() {
-            $('.download-pdf').text('A PDF version of your completed form is now available for download')
-                .css('pointer-events', 'auto');
-        },
-        error: function() {
-            $('.download-pdf').text('Not quite ready yet - a PDF version of your completed form will be available for download shortly')
-                .css('pointer-events', 'none');
-            console.warn(`Unable to find PDF, retrying ${pdfUrl} 10 seconds`);
-            setTimeout(checkLinkStatus, 10000);
+    let url = $('.download-pdf').attr('href');
+    let http = new XMLHttpRequest();
+    http.overrideMimeType("application/pdf");
+    http.open('GET', url, true);
+    http.onload = function (e) {
+        if (http.readyState === 4) {
+            if (http.status === 200) {
+                $('.download-pdf').text('A PDF version of your completed form is now available for download')
+                    .css('pointer-events', 'auto');
+            } else {
+                $('.download-pdf').text('Not quite ready yet - a PDF version of your completed form will be available for download shortly')
+                    .css('pointer-events', 'none');
+                console.warn(`Unable to find PDF, retrying ${url} in 10 seconds`);
+                setTimeout(function() { checkLinkStatus() }, 10000);
+            }
         }
-    })
+    };
+    http.send();
 }


### PR DESCRIPTION
# New

* Upon ET3 submission, if the generated PDF download is not ready yet, the link is disabled and the user is made aware that the file will be available shortly as opposed to getting a 404 error. (RST-1402: #100 & Hotfix: #102)

# Fixed

* Fix "Remove File" link to prevent it from showing when no file has been uploaded (RST-1381: #94)
* Fix JavaScript error caused by Dropzone being unable to find the uploader element. (RST-1397: #98)
* Prevent sessions being renewed when accessing the landing page after a period of over an hour away from the keyboard.

# Changed