### PR TITLE
v2.2.0

### DIFF
--- a/app/controllers/form_submissions_controller.rb
+++ b/app/controllers/form_submissions_controller.rb
@@ -3,7 +3,8 @@ class FormSubmissionsController < ApplicationController
 
   def index
     @reference_number = current_store.api_response[:data]["meta"]["BuildResponse"]["reference"]
-    @submission_date = Time.zone.parse(current_store.api_response[:data]["meta"]["BuildResponse"]["submitted_at"]).strftime('%d/%m/%Y %H:%M')
+    @submission_date = Time.zone.
+        parse(current_store.api_response[:data]["meta"]["BuildResponse"]["submitted_at"]).strftime('%d/%m/%Y')
     @pdf_url = current_store.api_response[:data]["meta"]["BuildResponse"]["pdf_url"]
     @office_address = current_store.api_response[:data]["meta"]["BuildResponse"]["office_address"]
     @office_phone_number = current_store.api_response[:data]["meta"]["BuildResponse"]["office_phone_number"]

--- a/app/views/form_submissions/index.html.slim
+++ b/app/views/form_submissions/index.html.slim
@@ -12,7 +12,7 @@
     br
     strong.bold.office-phone = @office_phone_number
   p 
-    | Submission Date:
+    | Submission Date:&nbsp;
     span.submission-date = @submission_date
     br
     br

--- a/config/application.rb
+++ b/config/application.rb
@@ -16,5 +16,7 @@ module Et3
     # -- all .rb files in that directory are automatically loaded.
 
     ActionView::Base.default_form_builder = GovukElementsFormBuilder::FormBuilder
+
+    config.time_zone = "London"
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -279,7 +279,7 @@ en:
       header: Session Expired
       content: |
         Your session has expired due to inactivity. The information you have provided has not been saved. We apologise for the inconvenience and request that you fill in the form again.
-      homepage_link: Service Homepage
+      homepage_link: Return to Employment Tribunal Response
     sidebar:
       header: Other Relevant Links
       claim_link: How to make a claim

--- a/spec/features/fill_in_whole_form_spec.rb
+++ b/spec/features/fill_in_whole_form_spec.rb
@@ -203,7 +203,7 @@ RSpec.feature "Fill in whole form", js: true do
 
     expect(form_submission_page).to have_submission_confirmation
     expect(form_submission_page.reference_number).to have_text "142000000100"
-    expect(form_submission_page.submission_date).to have_text "13/01/2018 14:00"
+    expect(form_submission_page.submission_date).to have_text "13/01/2018"
     expect(form_submission_page).to have_valid_pdf_download
 
   end


### PR DESCRIPTION
**Deployed to Prod 24/09/18**

# Fixed

# Change

* Link on expiry page now says "Return to Employment Tribunal Response" instead of "Service Homepage" (RST-1282: #104)
* Date of ET3 submission is now displayed to the user as London time (i.e. BST or GMT, depending on the day). (RST-1422: #105)

# New