### PR TITLE
Only Use Bootsnap in Production

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,8 +8,6 @@ end
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 5.2.0'
-# Add bootsnap for 5.2
-gem 'bootsnap', '~> 1.3'
 # Use postgresql as the database for Active Record
 gem 'pg', '~> 0.18'
 gem 'unicorn'
@@ -85,6 +83,11 @@ group :test do
   gem 'database_cleaner', '~> 1.5'
   gem 'webmock', '~> 3.3'
   gem 'faker', '~> 1.8'
+end
+
+group :production do
+  # Add bootsnap for 5.2
+  gem 'bootsnap', '~> 1.3'
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -1,4 +1,4 @@
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', __dir__)
 
 require 'bundler/setup' # Set up gems listed in the Gemfile.
-require 'bootsnap/setup' # Speed up boot time by caching expensive operations.
+require 'bootsnap/setup' if ENV['RAILS_ENV'] == 'production' # Speed up boot time by caching expensive operations.

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -1,4 +1,4 @@
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', __dir__)
 
 require 'bundler/setup' # Set up gems listed in the Gemfile.
-require 'bootsnap/setup' if Rails.env.production? # Speed up boot time by caching expensive operations.
+require 'bootsnap/setup' if ENV['RAILS_ENV'] == 'production' # Speed up boot time by caching expensive operations.

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -1,4 +1,4 @@
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', __dir__)
 
 require 'bundler/setup' # Set up gems listed in the Gemfile.
-require 'bootsnap/setup' if ENV['RAILS_ENV'] == 'production' # Speed up boot time by caching expensive operations.
+require 'bootsnap/setup' if Rails.env.production? # Speed up boot time by caching expensive operations.


### PR DESCRIPTION
This moves bootsnap into production environment only so as to avoid debugging issues until Ruby is patched.