### PR TITLE
RST-1547: Upgrade rack gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -216,7 +216,7 @@ GEM
       method_source (~> 0.9.0)
     public_suffix (3.0.2)
     puma (3.11.4)
-    rack (2.0.5)
+    rack (2.0.6)
     rack-proxy (0.6.4)
       rack
     rack-test (1.1.0)


### PR DESCRIPTION
2.0.5 -> 2.0.6 due to vulnerabilities