### PR TITLE
RST-1742: Add Privacy Notice to Footer

### DIFF
--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -4,4 +4,6 @@ class StaticPagesController < ApplicationController
   def expired; end
 
   def terms; end
+
+  def privacy; end
 end

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -40,6 +40,6 @@
               p = link_to(t('components.sidebar.download_link'), t('components.sidebar.download_href'), target: :_blank)
               hr
               p = link_to(t('components.sidebar.more_category_link'), t('components.sidebar.more_category_href'), target: :_blank)
-- content_for :footer_top
+- content_for :footer_support_links
   = render 'shared/footer_links'
 = render template: "layouts/govuk_template"

--- a/app/views/shared/_footer_links.html.slim
+++ b/app/views/shared/_footer_links.html.slim
@@ -1,2 +1,3 @@
-.column-one-third
-  = link_to(t('components.footer.terms'), terms_and_conditions_path)
+ul
+  li= link_to(t('components.footer.terms'), terms_and_conditions_path)
+  li= link_to(t('components.footer.privacy'), privacy_notice_path)

--- a/app/views/static_pages/_policy_elements.html.slim
+++ b/app/views/static_pages/_policy_elements.html.slim
@@ -2,7 +2,7 @@
   - case element
     - when String
       p = element.html_safe
-    - when Hash
+    - when Array
       ul.list.list-bullet
-        - element.values.flatten.each do |bullet_point|
+        - element.each do |bullet_point|
           li = bullet_point.html_safe

--- a/app/views/static_pages/privacy.html.slim
+++ b/app/views/static_pages/privacy.html.slim
@@ -26,7 +26,7 @@
 
   #sharing-your-data
     h4.heading-small = t('components.privacy_notice.sharing_your_data.header')
-    p = t('components.privacy_notice.sharing_your_data.content', terms_and_conditions_href: link_to(t('components.privacy_notice.terms_and_conditions_href'))).html_safe
+    p = t('components.privacy_notice.sharing_your_data.content', terms_and_conditions_href: link_to(t('components.privacy_notice.terms_and_conditions_href'), terms_and_conditions_path)).html_safe
 
   #receiving-notifications
     h4.heading-small = t('components.privacy_notice.receiving_notifications.header')

--- a/app/views/static_pages/privacy.html.slim
+++ b/app/views/static_pages/privacy.html.slim
@@ -1,0 +1,42 @@
+- content_for :form_page_title, t('components.privacy_notice.header')
+- content_for :page_title, raw("#{content_for :form_page_title} - Response to Claim - MoJ")
+.content-body.privacy-notice
+
+  p = t('components.privacy_notice.introduction',
+          terms_and_conditions_href: link_to(t('components.privacy_notice.terms_and_conditions_href'), terms_and_conditions_path)).html_safe
+
+  #who-manages-service
+    h4.heading-small = t('components.privacy_notice.who_manages.header')
+    - t('components.privacy_notice.who_manages.content',
+    personal_info_charter_href: link_to(t('components.privacy_notice.personal_info_charter_href'), 'https://www.gov.uk/government/organisations/ministry-of-justice/about/personal-information-charter')).each do |paragraph|
+      p = paragraph.html_safe
+
+  #personal-data
+    h4.heading-small = t('components.privacy_notice.personal_data.header')
+    = render 'static_pages/terms_elements', translated_content_array: t('components.privacy_notice.personal_data.content',
+            using_cookies_href: link_to(t('components.privacy_notice.using_cookies_href'), 'http://www.aboutcookies.org.uk/managing-cookies'))
+
+  #what-we-do-data
+    h4.heading-small = t('components.privacy_notice.what_we_do_data.header')
+    = render 'static_pages/terms_elements', translated_content_array: t('components.privacy_notice.what_we_do_data.content')
+
+  #your-rights
+    h4.heading-small = t('components.privacy_notice.your_rights.header')
+    = render 'static_pages/terms_elements', translated_content_array: t('components.privacy_notice.your_rights.content')
+
+  #sharing-your-data
+    h4.heading-small = t('components.privacy_notice.sharing_your_data.header')
+    p = t('components.privacy_notice.sharing_your_data.content', terms_and_conditions_href: link_to(t('components.privacy_notice.terms_and_conditions_href'))).html_safe
+
+  #receiving-notifications
+    h4.heading-small = t('components.privacy_notice.receiving_notifications.header')
+    - t('components.privacy_notice.receiving_notifications.content', contact_us_href: link_to(t('components.privacy_notice.receiving_notifications.contact_us_href'), '#')).each do |paragraph|
+      p = paragraph.html_safe
+
+  #how-to-complain
+    h4.heading-small = t('components.privacy_notice.how_to_complain.header')
+    - t('components.privacy_notice.how_to_complain.content',
+            ico_href: link_to(t('components.privacy_notice.how_to_complain.ico_href'),
+                    'https://ico.org.uk/global/contact-us')).each do |paragraph|
+      p = paragraph.html_safe
+

--- a/app/views/static_pages/privacy.html.slim
+++ b/app/views/static_pages/privacy.html.slim
@@ -13,16 +13,16 @@
 
   #personal-data
     h4.heading-small = t('components.privacy_notice.personal_data.header')
-    = render 'static_pages/terms_elements', translated_content_array: t('components.privacy_notice.personal_data.content',
+    = render 'static_pages/policy_elements', translated_content_array: t('components.privacy_notice.personal_data.content',
             using_cookies_href: link_to(t('components.privacy_notice.using_cookies_href'), 'http://www.aboutcookies.org.uk/managing-cookies'))
 
   #what-we-do-data
     h4.heading-small = t('components.privacy_notice.what_we_do_data.header')
-    = render 'static_pages/terms_elements', translated_content_array: t('components.privacy_notice.what_we_do_data.content')
+    = render 'static_pages/policy_elements', translated_content_array: t('components.privacy_notice.what_we_do_data.content')
 
   #your-rights
     h4.heading-small = t('components.privacy_notice.your_rights.header')
-    = render 'static_pages/terms_elements', translated_content_array: t('components.privacy_notice.your_rights.content')
+    = render 'static_pages/policy_elements', translated_content_array: t('components.privacy_notice.your_rights.content')
 
   #sharing-your-data
     h4.heading-small = t('components.privacy_notice.sharing_your_data.header')

--- a/app/views/static_pages/terms.html.slim
+++ b/app/views/static_pages/terms.html.slim
@@ -3,7 +3,7 @@
 .content-body.terms-conditions
 
   p = t('components.terms_and_conditions.introduction',
-          privacy_policy_href: link_to(t('components.terms_and_conditions.common.privacy_policy_href'), '#')).html_safe
+          privacy_policy_href: link_to(t('components.terms_and_conditions.privacy_policy_href'), privacy_notice_path)).html_safe
 
   #who-we-are
     h4.heading-small = t('components.terms_and_conditions.who_we_are.header')
@@ -18,8 +18,8 @@
   #sharing-storing-data
     h4.heading-small = t('components.terms_and_conditions.sharing_storing_data.header')
     p = t('components.terms_and_conditions.sharing_storing_data.content',
-            privacy_policy_href: link_to(t('components.terms_and_conditions.common.privacy_policy_href'), '#'),
-            cookie_policy_href: link_to(t('components.terms_and_conditions.common.cookie_policy_href'), '#')).html_safe
+            privacy_policy_href: link_to(t('components.terms_and_conditions.privacy_policy_href'), privacy_notice_path),
+            cookie_policy_href: link_to(t('components.terms_and_conditions.cookie_policy_href'), '#')).html_safe
 
   #laws-applying-service
     h4.heading-small = t('components.terms_and_conditions.laws_applied.header')
@@ -32,9 +32,9 @@
   #entering-personally-sensitive-information
     h4.heading-small = t('components.terms_and_conditions.entering_sensitive_info.header')
     = render 'static_pages/policy_elements', translated_content_array: t('components.terms_and_conditions.entering_sensitive_info.content',
-            privacy_policy_href: link_to(t('components.terms_and_conditions.common.privacy_policy_href'), '#'))
+            privacy_policy_href: link_to(t('components.terms_and_conditions.privacy_policy_href'), privacy_notice_path))
 
   #disclaimer
     h4.heading-small = t('components.terms_and_conditions.disclaimer.header')
     = render 'static_pages/policy_elements', translated_content_array: t('components.terms_and_conditions.disclaimer.content',
-            contact_href: link_to(t('components.terms_and_conditions.common.contact_href'), '#'))
+            contact_href: link_to(t('components.terms_and_conditions.contact_href'), '#'))

--- a/app/views/static_pages/terms.html.slim
+++ b/app/views/static_pages/terms.html.slim
@@ -23,18 +23,18 @@
 
   #laws-applying-service
     h4.heading-small = t('components.terms_and_conditions.laws_applied.header')
-    = render 'static_pages/terms_elements', translated_content_array: t('components.terms_and_conditions.laws_applied.content')
+    = render 'static_pages/policy_elements', translated_content_array: t('components.terms_and_conditions.laws_applied.content')
 
   #how-to-use-responsibly
     h4.heading-small = t('components.terms_and_conditions.how_to_use.header')
-    = render 'static_pages/terms_elements', translated_content_array: t('components.terms_and_conditions.how_to_use.content')
+    = render 'static_pages/policy_elements', translated_content_array: t('components.terms_and_conditions.how_to_use.content')
 
   #entering-personally-sensitive-information
     h4.heading-small = t('components.terms_and_conditions.entering_sensitive_info.header')
-    = render 'static_pages/terms_elements', translated_content_array: t('components.terms_and_conditions.entering_sensitive_info.content',
+    = render 'static_pages/policy_elements', translated_content_array: t('components.terms_and_conditions.entering_sensitive_info.content',
             privacy_policy_href: link_to(t('components.terms_and_conditions.common.privacy_policy_href'), '#'))
 
   #disclaimer
     h4.heading-small = t('components.terms_and_conditions.disclaimer.header')
-    = render 'static_pages/terms_elements', translated_content_array: t('components.terms_and_conditions.disclaimer.content',
+    = render 'static_pages/policy_elements', translated_content_array: t('components.terms_and_conditions.disclaimer.content',
             contact_href: link_to(t('components.terms_and_conditions.common.contact_href'), '#'))

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -366,12 +366,9 @@ cy:
       data_content: "Byddwn yn anfon copi o'r ffurflen hon at yr hawlydd a'r Gwasanaeth Cynghori, Cymodi a Chyflafareddu (ACAS). Byddwn yn rhoi'r wybodaeth yr ydych yn ei rhoi inni ar y ffurflen hon ar gyfrifiadur. Mae hyn yn ein helpu i fonitro cynnydd a chynhyrchu ystadegau. Trosglwyddir yr wybodaeth a ddarperir ar y ffurflen hon i'r Adran Busnes, Arloesedd a Sgiliau i gynorthwyo ymchwil i'r defnydd a wneir o dribiwnlysoedd cyflogaeth ac effeithiolrwydd y tribiwnlysoedd hynny."
       start_now: Dechrau nawr
     terms_and_conditions:
-      common:
-        privacy_policy_href: polisi preifatrwydd
-        cookie_policy_href: polisi cwcis
-        contact_href: Cysylltwch â ni
       header: Telerau ac amodau
       introduction: Trwy ddefnyddio’r gwasanaeth hwn rydych yn cytuno i’r telerau defnydd hyn. Mae hyn yn cynnwys y %{privacy_policy_href}.
+      privacy_policy_href: polisi preifatrwydd
       who_we_are:
         header: Pwy ydym ni
         content:
@@ -385,23 +382,22 @@ cy:
       sharing_storing_data:
         header: Rhannu a chadw data
         content: Mae ein %{privacy_policy_href} yn egluro lle mae’ch data yn cael ei storio a gyda phwy mae’n cael ei rannu. Mae ein %{cookie_policy_href} yn egluro sut mae’r gwasanaeth hwn yn defnyddio ac yn storio cwcis.
+      cookie_policy_href: polisi cwcis
       laws_applied:
         header: Deddfau sy’n berthnasol i’r gwasanaeth hwn
         content:
           - "Bydd y defnydd a wnewch o’r gwasanaeth hwn ac unrhyw anghydfod sy’n codi o’i ddefnyddio yn cael eu rheoli a’u dehongli yn unol â chyfreithiau Cymru a Lloegr, gan gynnwys, ond nid yn gyfyngedig i:"
-          - law_bullets:
-              - Deddf Camddefnyddio Cyfrifiaduron 1990
-              - Rheoliadau Cyffredinol Diogelu Data
-              - Deddf Galluedd Meddyliol 2005
+          - - Deddf Camddefnyddio Cyfrifiaduron 1990
+            - Rheoliadau Cyffredinol Diogelu Data
+            - Deddf Galluedd Meddyliol 2005
       how_to_use:
         header: Sut i ddefnyddio’r gwasanaeth hwn yn gyfrifol
         content:
           - Mae peryglon yn gysylltiedig â defnyddio cyfrifiadur sy'n cael ei rannu (e.e. mewn caffi rhyngrwyd), i ddefnyddio’r gwasanaeth hwn. Eich cyfrifoldeb chi yw bod yn ymwybodol o’r peryglon hyn ac osgoi defnyddio unrhyw gyfrifiadur lle mae posibilrwydd y gall eraill weld eich gwybodaeth bersonol. Chi sy’n gyfrifol os ydych chi’n dewis gadael cyfrifiadur heb ei ddiogelu tra byddwch yn defnyddio’r gwasanaeth hwn.
           - "Mae’n rhaid i chi gymryd gofal eich hunan i sicrhau nad yw’r ffordd yr ydych yn cael mynediad at y gwasanaeth hwn yn eich gadael yn agored i’r perygl o:"
-          - risk_bullets:
-              - feirysau
-              - cod cyfrifiadur maleisus
-              - neu ymyrraeth o fath arall a allai achosi difrod i’ch system gyfrifiadurol eich hunan
+          - - feirysau
+            - cod cyfrifiadur maleisus
+            - neu ymyrraeth o fath arall a allai achosi difrod i’ch system gyfrifiadurol eich hunan
           - Ni ddylech gamddefnyddio ein gwasanaeth drwy gyflwyno’n fwriadol firysau, cnafon (trojans), mwydod (worms), bomiau rhesymeg (logic bombs) neu unrhyw ddeunydd arall maleisus neu niweidiol i dechnoleg.
           - Ni ddylech geisio cael mynediad heb awdurdod at y gwasanaeth hwn, y system lle caiff ei storio nac unrhyw weinydd, cyfrifiadur neu gronfa ddata sy’n gysylltiedig ag o. Ni ddylech ymosod ar ein gwefan drwy ymosodiad gwrthod gwasanaeth neu ymosodiad gwrthod gwasanaeth a ddosbarthwyd.
       entering_sensitive_info:
@@ -409,54 +405,50 @@ cy:
         content:
           - Mae’r gwasanaeth ar-lein hwn yn cynnwys nifer o feysydd testun rhydd lle fe’ch gwahoddir i nodi gwybodaeth bersonol sensitif.
           - "Os ydych yn rhoi gwybodaeth am eich:"
-          - information_bullets:
-              - credoau crefyddol
-              - cyfeiriadedd rhywiol neu’ch bywyd rhywiol
-              - tarddiad hiliol neu’ch tarddiad ethnig
-              - barnau gwleidyddol
-              - credoau crefyddol neu’ch credoau athronyddol
-              - aelodaeth undeb lafur
-              - data genetig neu ddata biometrig
-              - gwybodaeth am eich iechyd
+          - - credoau crefyddol
+            - cyfeiriadedd rhywiol neu’ch bywyd rhywiol
+            - tarddiad hiliol neu’ch tarddiad ethnig
+            - barnau gwleidyddol
+            - credoau crefyddol neu’ch credoau athronyddol
+            - aelodaeth undeb lafur
+            - data genetig neu ddata biometrig
+            - gwybodaeth am eich iechyd
           - Rydych yn rhoi eich caniatâd inni ddefnyddio’r wybodaeth hon i ymdrin â’ch cais
           - I gael rhagor o wybodaeth am sut rydym yn casglu a storio eich data personol, gweler y %{privacy_policy_href}.
       disclaimer:
         header: Ymwrthodiad
         content:
           - "Er ein bod yn ymdrechu i gadw gwybodaeth yn gyfredol, nid ydym yn darparu unrhyw warantau, amodau neu sicrwydd y bydd:"
-          - effort_bullets:
-              - yn gyfredol
-              - yn ddiogel
-              - yn gywir
-              - yn gyflawn
-              - yn rhydd o fygiau neu feirysau
+          - - yn gyfredol
+            - yn ddiogel
+            - yn gywir
+            - yn gyflawn
+            - yn rhydd o fygiau neu feirysau
           - Nid ydym yn cyhoeddi cyngor. Dylech gael cyngor proffesiynol neu gyngor arbenigol cyn gwneud unrhyw beth yn seiliedig ar yr wybodaeth yn y gwasanaeth.
           - "Nid ydym yn atebol am unrhyw golled neu ddifrod a all ddeillio o ddefnyddio’r gwasanaeth hwn. Mae hyn yn cynnwys:"
-          - not_liable_bullets:
-              - unrhyw golledion uniongyrchol, anuniongyrchol neu ganlyniadol
-              - unrhyw golled neu ddifrod a achoswyd gan gamweddau sifil (‘tort’, yn cynnwys esgeuluster), torri amodau contract neu fel arall
-              - defnyddio’r gwasanaeth hwn, GOV.UK ac unrhyw wefannau sydd â dolenni i neu o’r gwefan
-              - methu â defnyddio’r gwasanaeth hwn, GOV.UK ac unrhyw wefannau sydd â dolenni i neu o’r gwefan
+          - - unrhyw golledion uniongyrchol, anuniongyrchol neu ganlyniadol
+            - unrhyw golled neu ddifrod a achoswyd gan gamweddau sifil (‘tort’, yn cynnwys esgeuluster), torri amodau contract neu fel arall
+            - defnyddio’r gwasanaeth hwn, GOV.UK ac unrhyw wefannau sydd â dolenni i neu o’r gwefan
+            - methu â defnyddio’r gwasanaeth hwn, GOV.UK ac unrhyw wefannau sydd â dolenni i neu o’r gwefan
           - Mae hyn yn berthnasol os oedd y golled neu’r difrod yn rhagweladwy, wedi codi wrth i’r broses arferol fynd rhagddo, neu os oeddech wedi ein cynghori y gallai ddigwydd.
           - "Mae hyn yn cynnwys, ond nid yw’n gyfyngedig i golli eich:"
-          - loss_bullets:
-              - incwm neu refeniw
-              - cyflog, budd-daliadau neu daliadau eraill
-              - busnes
-              - elw neu gontractau
-              - cyfleoedd
-              - cynilion a ragwelwyd
-              - data
-              - ewyllys da neu’ch enw da
-              - eiddo diriaethol
-              - eiddo anniriaethol, yn cynnwys colled, llygredd neu ddifrod o ddata neu unrhyw system gyfrifiadurol
-              - gwastraff o amser rheolwyr neu amser swyddfa
+          - - incwm neu refeniw
+            - cyflog, budd-daliadau neu daliadau eraill
+            - busnes
+            - elw neu gontractau
+            - cyfleoedd
+            - cynilion a ragwelwyd
+            - data
+            - ewyllys da neu’ch enw da
+            - eiddo diriaethol
+            - eiddo anniriaethol, yn cynnwys colled, llygredd neu ddifrod o ddata neu unrhyw system gyfrifiadurol
+            - gwastraff o amser rheolwyr neu amser swyddfa
           - "Efallai y byddwn yn parhau i fod yn atebol am:"
-          - liable_bullets:
-              - farwolaeth neu anaf personol sy’n codi o’n hesgeuluster
-              - camliwio twyllodrus
-              - unrhyw atebolrwydd arall na ellir ei eithrio neu ei gyfyngu dan y gyfraith berthnasol
+          - - farwolaeth neu anaf personol sy’n codi o’n hesgeuluster
+            - camliwio twyllodrus
+            - unrhyw atebolrwydd arall na ellir ei eithrio neu ei gyfyngu dan y gyfraith berthnasol
           - "%{contact_href} i gael rhagor o wybodaeth."
+      contact_href: Cysylltwch â ni
     privacy_notice:
       header: Polisi preifatrwydd
       introduction: Mae'r polisi preifatrwydd hwn yn egluro pam ein bod yn casglu eich data personol, yr hyn a wnawn ag ef, a'ch hawliau. Mae mwy o wybodaeth am ddefnyddio'r gwasanaeth hwn yn y %{terms_and_conditions_href}.

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -298,6 +298,7 @@ cy:
       more_category_href: "http://gov.uk/browse/working"
     footer:
       terms: Telerau ac amodau
+      privacy: Polisi preifatrwydd
     confirmation_of_supplied_details:
       header: "Cadarnhau'r manylion a roddwyd "
       receipt_header: E-bost yn cadarnhau bod y manylion wedi'u hanfon
@@ -456,6 +457,60 @@ cy:
               - camliwio twyllodrus
               - unrhyw atebolrwydd arall na ellir ei eithrio neu ei gyfyngu dan y gyfraith berthnasol
           - "%{contact_href} i gael rhagor o wybodaeth."
+    privacy_notice:
+      header: Polisi preifatrwydd
+      introduction: Mae'r polisi preifatrwydd hwn yn egluro pam ein bod yn casglu eich data personol, yr hyn a wnawn ag ef, a'ch hawliau. Mae mwy o wybodaeth am ddefnyddio'r gwasanaeth hwn yn y %{terms_and_conditions_href}.
+      terms_and_conditions_href: telerau ac amodau
+      who_manages:
+        header: Pwy sy'n rheoli'r gwasanaeth hwn
+        content:
+          - Mae'r gwasanaeth hwn yn cael ei reoli gan Wasanaeth Llysoedd a Thribiwnlysoedd ei Mawrhydi (GLlTEM) ac rydym yn gyfrifol am ddiogelu'r data personol a ddarperir gennych.
+          - Mae GLlTEM yn asiantaeth weithredol o'r Weinyddiaeth Cyfiawnder (MoJ). MoJ yw'r rheolydd data ac mae ei %{personal_info_charter_href} yn esbonio mwy am sut maent yn prosesu data personol.
+          - Pan fyddwch yn defnyddio'r gwasanaeth hwn byddwn ni (GLlTEM) yn gofyn ichi ddarparu rhywfaint o ddata personol.
+      personal_info_charter_href: siarter gwybodaeth bersonol
+      personal_data:
+        header: Beth yw'r data personol a gasglwn
+        content:
+          - "Mae'r data personol a gasglwn yn cynnwys:"
+          - - eich enw, cyfeiriad a'ch manylion cyswllt
+            - enw, cyfeiriad a manylion cyswllt eich cynrychiolydd - os oes gennych un
+            - gwybodaeth sy'n dweud wrthym os ydych chi'n agor neges e-bost gennym ni, neu os byddwch yn clicio ar ddolen mewn e-bost
+            - gwybodaeth am sut rydych yn defnyddio'r gwasanaeth hwn, fel eich cyfeiriad IP a'r porwr gwe rydych yn ei ddefnyddio. Rydym yn gwneud hyn drwy %{using_cookies_href}.
+      using_cookies_href: ddefnyddio cwcis
+      what_we_do_data:
+        header: Beth rydym yn ei wneud gyda'ch data
+        content:
+          - "Rydym yn casglu eich data personol i:"
+          - - brosesu eich ymateb
+            - bodloni gofynion cyfreithiol
+            - gwneud gwelliannau i'r gwasanaeth hwn
+          - Caiff eich data personol ei brosesu gan ein staff yn y Deyrnas Unedig a chaiff y data ei storio yn y Deyrnas Unedig.
+          - Byddwn yn anfon copi o'ch ymateb at yr hawlydd ac Acas. Byddwn yn rhannu gwybodaeth ar y ffurflen hon â'r Adran Busnes, Ynni a Strategaeth Ddiwydiannol (BEIS) i helpu gyda'u gwaith ymchwil ar dribiwnlysoedd cyflogaeth.
+          - Rydym yn defnyddio Sendgrid i anfon negeseuon e-bost gan ddefnyddio seilwaith rhyngrwyd byd-eang. Ni allwn warantu y bydd negeseuon e-bost yn cael eu cadw yn yr Ardal Economaidd Ewropeaidd (EEA).
+      your_rights:
+        header: Eich hawliau
+        content:
+          - "Gallwch ofyn:"
+          - - i weld y data personol sydd gennym amdanoch
+            - i'r data personol gael ei gywiro
+            - i'r data personol gael ei ddileu (bydd hyn yn dibynnu ar yr amgylchiadau)
+            - bod mynediad at y data personol wedi'i gyfyngu (er enghraifft, gallwch ofyn i'ch data gael ei storio'n hirach a pheidio â chael ei ddileu'n awtomatig)
+          - Anfonwch e-bost atom os ydych eisiau gweld yr wybodaeth hon.
+      sharing_your_data:
+        header: Rhannu eich data
+        content: Rydym yn caniatáu i Google ddefnyddio neu rannu ein data ar gyfer dadansoddi ein gwefan. Cewch wybod am hyn yn ein %{terms_and_conditions_href}.
+      receiving_notifications:
+        header: Derbyn hysbysiadau
+        content:
+          - Fel rhan o'ch ymateb, mae'n bosibl y byddwn yn gofyn a ydych yn dymuno derbyn hysbysiadau gyda diweddariadau. Byddwn yn gofyn am eich enw a’r manylion cyswllt sydd orau gennych.
+          - Gallwch danysgrifio o dderbyn negeseuon testun drwy ddilyn y camau a nodir yn y neges testun. %{contact_us_href} os ydych eisiau canslo diweddariadau e-bost.
+        contact_us_href: Cysylltwch â ni
+      how_to_complain:
+        header: Sut i gwyno
+        content:
+          - Os ydych eisiau cwyno am sut rydym wedi ymdrin â'ch data personol, anfonwch e-bost atom.
+          - Gallwch gwyno i %{ico_href} os nad ydych yn fodlon â'n hymateb neu'n credu nad ydym yn prosesu eich data personol yn unol â’r gyfraith.
+        ico_href: Swyddfa'r Comisiynydd Gwybodaeth
     respondents_details:
       header: "Manylion yr Atebydd "
     claimants_details:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -302,6 +302,7 @@ en:
       more_category_href: http://gov.uk/browse/working
     footer:
       terms: Terms and conditions
+      privacy: Privacy policy
     confirmation_of_supplied_details:
       header: Confirmation of Supplied Details
       receipt_header: Email Receipt

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -386,7 +386,7 @@ en:
       sharing_storing_data:
         header: Sharing and storing data
         content: Our %{privacy_policy_href} explains where your data is stored, and who it is shared with. Our %{cookie_policy_href} explains how this service uses and stores cookies.
-        cookie_policy_href: cookie policy
+      cookie_policy_href: cookie policy
       laws_applied:
         header: Laws applying to this service
         content:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -461,6 +461,60 @@ en:
               - fraudulent misrepresentation
               - any other liability which cannot be excluded or limited under applicable law
           - "%{contact_href} for further information"
+    privacy_notice:
+      header: Privacy policy
+      introduction: This privacy policy explains why we collect your personal data, what we do with it, and your rights. More information about using this service is in the %{terms_and_conditions_href}.
+      terms_and_conditions_href: terms and conditions
+      who_manages:
+        header: Who manages this service
+        content:
+          - This service is managed by Her Majesty’s Courts and Tribunals Service (HMCTS) and we’re responsible for protecting the personal data you provide.
+          - HMCTS is an executive agency of the Ministry of Justice (MoJ). The MoJ is the data controller and their %{personal_info_charter_href} explains more about how they process personal data.
+          - When you use this service we (HMCTS) will ask you to provide some personal data.
+      personal_info_charter_href: personal information charter
+      personal_data:
+        header: What is the personal data that we collect
+        content:
+          - "The personal data we collect includes:"
+          - - your name, address and contact details
+            - your representative’s name, address and contact details - if you have one
+            - information that tells us if you open an email from us, or click on a link in an email
+            - "information about how you use this service, like your IP address and the web browser you use. We do this by %{using_cookies_href}."
+      using_cookies_href: using cookies
+      what_we_do_data:
+        header: What we do with your data
+        content:
+          - "We collect your personal data to:"
+          - - process your response
+            - meet legal requirements
+            - make improvements to this service
+          - Your personal data is processed by our staff in the UK and the data is stored in the UK.
+          - We’ll send a copy of your response to the claimant and Acas. We’ll share information provided on this form with the Department for Business, Energy and Industrial Strategy (BEIS) to help with their research on employment tribunals.
+          - We use Sendgrid to send emails using global internet infrastructure. We can’t guarantee that emails will be routed within the European Economic Area (EEA).
+      your_rights:
+        header: Your rights
+        content:
+          - "You can ask:"
+          - - to see the personal data that we hold on you
+            - to have the personal data corrected
+            - to have the personal data removed or deleted (this will depend on the circumstances)
+            - that access to the personal data is restricted (for example, you can ask to have your data stored for longer, and not automatically deleted)
+          - Email if you want to see any of this information.
+      sharing_your_data:
+        header: Sharing your data
+        content: We allow Google to use or share our website analytics data, find out about this in our %{terms_and_conditions_href}.
+      receiving_notifications:
+        header: Receiving notifications
+        content:
+          - As part of your response, we may ask if you want to receive notifications with updates. We’ll ask for your name and preferred contact details.
+          - You can unsubscribe from receiving text messages by following the steps mentioned in the text message. %{contact_us_href} if you want to cancel email updates.
+        contact_us_href: Contact us
+      how_to_complain:
+        header: How to complain
+        content:
+          - If you want to complain about how we’ve handled your personal data, send an email.
+          - You can complain to the %{ico_href} if you are unsatisfied with our response or believe we are not legally processing your personal data.
+        ico_href: Information Commissioner's Office
     respondents_details:
       header: "Respondent's Details"
     claimants_details:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -370,12 +370,9 @@ en:
       data_content: We will send a copy of this form to the claimant and the Advisory, Conciliation and Arbitration Service (ACAS). We will put the information you give us on this form onto a computer. This helps us to monitor progress and produce statistics. Information provided on this form is passed to the Department for Business, Innovation and Skills to assist research into the use and effectiveness of employment tribunals.
       start_now: Start now
     terms_and_conditions:
-      common:
-        privacy_policy_href: privacy policy
-        cookie_policy_href: cookie policy
-        contact_href: Contact us
       header: Terms and conditions
       introduction: By using this service you’re agreeing to these terms of use. This includes the %{privacy_policy_href}.
+      privacy_policy_href: privacy policy
       who_we_are:
         header: Who we are
         content:
@@ -389,23 +386,22 @@ en:
       sharing_storing_data:
         header: Sharing and storing data
         content: Our %{privacy_policy_href} explains where your data is stored, and who it is shared with. Our %{cookie_policy_href} explains how this service uses and stores cookies.
+        cookie_policy_href: cookie policy
       laws_applied:
         header: Laws applying to this service
         content:
           - "Your use of this service and any dispute arising from its use will be governed by and construed in accordance with the laws of England and Wales, including but not limited to the:"
-          - law_bullets:
-              - Computer Misuse Act 1990
-              - General Data Protection Regulations
-              - Mental Capacity Act 2005
+          - - Computer Misuse Act 1990
+            - General Data Protection Regulations
+            - Mental Capacity Act 2005
       how_to_use:
         header: How to use this service responsibly
         content:
           - There are risks in using a shared computer (for example, in a library) to access this service. It’s your responsibility to be aware of these risks and to avoid using any computer which may leave your personal information accessible to others. You’re responsible if you choose to leave a computer unprotected while using this service.
           - "You must take your own precautions to ensure that the way you access this service does not expose you to the risk of:"
-          - risk_bullets:
-              - viruses
-              - malicious computer code
-              - other forms of interference which may damage your computer system
+          - - viruses
+            - malicious computer code
+            - other forms of interference which may damage your computer system
           - You must not misuse this service by knowingly introducing viruses, trojans, worms, logic bombs or other material which is malicious or technologically harmful.
           - You must not attempt to gain unauthorised access to this service, the system on which it is stored, or any server, computer or database connected to it. You must not attack this site using a denial-of-service attack or a distributed denial-of-service attack.
       entering_sensitive_info:
@@ -413,54 +409,50 @@ en:
         content:
           - This online service contains several free-text fields in which you will need to enter information that is personally sensitive.
           - "If you enter information about your:"
-          - information_bullets:
-              - religious beliefs
-              - sexual orientation or sex life
-              - racial or ethnic origins
-              - political opinions
-              - religious or philosophical beliefs
-              - trade union membership
-              - generic data or biometric data
-              - health data
+          - - religious beliefs
+            - sexual orientation or sex life
+            - racial or ethnic origins
+            - political opinions
+            - religious or philosophical beliefs
+            - trade union membership
+            - generic data or biometric data
+            - health data
           - You give us your consent to processing this information for the purpose of dealing with your application
           - For more information about how we collect and store your personal data, see the %{privacy_policy_href}.
       disclaimer:
         header: Disclaimer
         content:
           - "While we make every effort to keep information up to date, we don’t provide any guarantees, conditions or warranties that it will be:"
-          - effort_bullets:
-              - current
-              - secure
-              - accurate
-              - complete
-              - free from bugs or viruses
+          - - current
+            - secure
+            - accurate
+            - complete
+            - free from bugs or viruses
           - We don’t publish advice. You should get professional or specialist advice before doing anything on the basis of the information in the service.
           - "We’re not liable for any loss or damage that may come from using this service. This includes:"
-          - not_liable_bullets:
-              - any direct, indirect or consequential losses
-              - any loss or damage caused by civil wrongs (‘tort’, including negligence), breach of contract or otherwise
-              - use of this service, GOV.UK and any websites that are linked to or from it
-              - the inability to use this service, GOV.UK and any websites that are linked to or from it
+          - - any direct, indirect or consequential losses
+            - any loss or damage caused by civil wrongs (‘tort’, including negligence), breach of contract or otherwise
+            - use of this service, GOV.UK and any websites that are linked to or from it
+            - the inability to use this service, GOV.UK and any websites that are linked to or from it
           - This applies if the loss or damage was foreseeable, arose in the normal course of things or you advised us that it might happen.
           - "This includes (but isn’t limited to) the loss of your:"
-          - loss_bullets:
-              - income or revenue
-              - salary, benefits or other payments
-              - business
-              - profits or contracts
-              - opportunity
-              - anticipated savings
-              - data
-              - goodwill or reputation
-              - tangible property
-              - intangible property, including loss, corruption or damage to data or any computer system
-              - wasted management or office time
+          - - income or revenue
+            - salary, benefits or other payments
+            - business
+            - profits or contracts
+            - opportunity
+            - anticipated savings
+            - data
+            - goodwill or reputation
+            - tangible property
+            - intangible property, including loss, corruption or damage to data or any computer system
+            - wasted management or office time
           - "We may still be liable for:"
-          - liable_bullets:
-              - death or personal injury arising from our negligence
-              - fraudulent misrepresentation
-              - any other liability which cannot be excluded or limited under applicable law
+          - - death or personal injury arising from our negligence
+            - fraudulent misrepresentation
+            - any other liability which cannot be excluded or limited under applicable law
           - "%{contact_href} for further information"
+      contact_href: Contact us
     privacy_notice:
       header: Privacy policy
       introduction: This privacy policy explains why we collect your personal data, what we do with it, and your rights. More information about using this service is in the %{terms_and_conditions_href}.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,6 +15,7 @@ Rails.application.routes.draw do
       get "form_submission", to: "form_submissions#index"
     end
     get "/terms" => 'static_pages#terms', as: 'terms_and_conditions'
+    get "/privacy" => 'static_pages#privacy', as: 'privacy_notice'
     root 'static_pages#index'
     delete "/respond/confirmation_of_supplied_details/remove_rtf" => 'confirmation_of_supplied_details#destroy_rtf', as: :remove_rtf
     mount ApiProxy.new(backend: "#{ENV.fetch('ET_API_URL', 'http://api.et.127.0.0.1.nip.io:3100/api')}/v2/build_blob", streaming: false), at: "/api/v2/build_blob"

--- a/spec/features/access_privacy_spec.rb
+++ b/spec/features/access_privacy_spec.rb
@@ -1,0 +1,413 @@
+require 'rails_helper'
+
+RSpec.feature "Access Privacy", js: true do
+  include ET3::Test::I18n
+
+  before do
+    stub_et_api
+    stub_build_blob_to_azure
+  end
+
+  scenario "from start page" do
+    start_page.load(locale: current_locale_parameter)
+
+    start_page.privacy_notice.click
+
+    expect(privacy_notice_page).to be_displayed
+    expect(privacy_notice_page).to have_header
+
+    expect(privacy_notice_page).to have_introduction
+
+    expect(privacy_notice_page.who_manages).to have_header
+    privacy_notice_page.who_manages.assert_content
+
+    expect(privacy_notice_page.personal_data).to have_header
+    privacy_notice_page.personal_data.assert_content
+
+    expect(privacy_notice_page.what_we_do_data).to have_header
+    privacy_notice_page.what_we_do_data.assert_content
+
+    expect(privacy_notice_page.your_rights).to have_header
+    privacy_notice_page.your_rights.assert_content
+
+    expect(privacy_notice_page.sharing_your_data).to have_header
+    privacy_notice_page.sharing_your_data.assert_content
+
+    expect(privacy_notice_page.receiving_notifications).to have_header
+    privacy_notice_page.receiving_notifications.assert_content
+
+    expect(privacy_notice_page.how_to_complain).to have_header
+    privacy_notice_page.how_to_complain.assert_content
+  end
+
+  scenario "from respondent's details page" do
+    respondents_details_page.load(locale: current_locale_parameter)
+
+    respondents_details_page.privacy_notice.click
+
+    expect(privacy_notice_page).to be_displayed
+    expect(privacy_notice_page).to have_header
+
+    expect(privacy_notice_page).to have_introduction
+
+    expect(privacy_notice_page.who_manages).to have_header
+    privacy_notice_page.who_manages.assert_content
+
+    expect(privacy_notice_page.personal_data).to have_header
+    privacy_notice_page.personal_data.assert_content
+
+    expect(privacy_notice_page.what_we_do_data).to have_header
+    privacy_notice_page.what_we_do_data.assert_content
+
+    expect(privacy_notice_page.your_rights).to have_header
+    privacy_notice_page.your_rights.assert_content
+
+    expect(privacy_notice_page.sharing_your_data).to have_header
+    privacy_notice_page.sharing_your_data.assert_content
+
+    expect(privacy_notice_page.receiving_notifications).to have_header
+    privacy_notice_page.receiving_notifications.assert_content
+
+    expect(privacy_notice_page.how_to_complain).to have_header
+    privacy_notice_page.how_to_complain.assert_content
+  end
+
+  scenario "from claimant's details page" do
+    claimants_details_page.load(locale: current_locale_parameter)
+
+    claimants_details_page.privacy_notice.click
+
+    expect(privacy_notice_page).to be_displayed
+    expect(privacy_notice_page).to have_header
+
+    expect(privacy_notice_page).to have_introduction
+
+    expect(privacy_notice_page.who_manages).to have_header
+    privacy_notice_page.who_manages.assert_content
+
+    expect(privacy_notice_page.personal_data).to have_header
+    privacy_notice_page.personal_data.assert_content
+
+    expect(privacy_notice_page.what_we_do_data).to have_header
+    privacy_notice_page.what_we_do_data.assert_content
+
+    expect(privacy_notice_page.your_rights).to have_header
+    privacy_notice_page.your_rights.assert_content
+
+    expect(privacy_notice_page.sharing_your_data).to have_header
+    privacy_notice_page.sharing_your_data.assert_content
+
+    expect(privacy_notice_page.receiving_notifications).to have_header
+    privacy_notice_page.receiving_notifications.assert_content
+
+    expect(privacy_notice_page.how_to_complain).to have_header
+    privacy_notice_page.how_to_complain.assert_content
+  end
+
+  scenario "from earnings and benefits page" do
+    earnings_and_benefits_page.load(locale: current_locale_parameter)
+
+    earnings_and_benefits_page.privacy_notice.click
+
+    expect(privacy_notice_page).to be_displayed
+    expect(privacy_notice_page).to have_header
+
+    expect(privacy_notice_page).to have_introduction
+
+    expect(privacy_notice_page.who_manages).to have_header
+    privacy_notice_page.who_manages.assert_content
+
+    expect(privacy_notice_page.personal_data).to have_header
+    privacy_notice_page.personal_data.assert_content
+
+    expect(privacy_notice_page.what_we_do_data).to have_header
+    privacy_notice_page.what_we_do_data.assert_content
+
+    expect(privacy_notice_page.your_rights).to have_header
+    privacy_notice_page.your_rights.assert_content
+
+    expect(privacy_notice_page.sharing_your_data).to have_header
+    privacy_notice_page.sharing_your_data.assert_content
+
+    expect(privacy_notice_page.receiving_notifications).to have_header
+    privacy_notice_page.receiving_notifications.assert_content
+
+    expect(privacy_notice_page.how_to_complain).to have_header
+    privacy_notice_page.how_to_complain.assert_content
+  end
+
+  scenario "from response page" do
+    response_page.load(locale: current_locale_parameter)
+
+    response_page.privacy_notice.click
+
+
+    expect(privacy_notice_page).to be_displayed
+    expect(privacy_notice_page).to have_header
+
+    expect(privacy_notice_page).to have_introduction
+
+    expect(privacy_notice_page.who_manages).to have_header
+    privacy_notice_page.who_manages.assert_content
+
+    expect(privacy_notice_page.personal_data).to have_header
+    privacy_notice_page.personal_data.assert_content
+
+    expect(privacy_notice_page.what_we_do_data).to have_header
+    privacy_notice_page.what_we_do_data.assert_content
+
+    expect(privacy_notice_page.your_rights).to have_header
+    privacy_notice_page.your_rights.assert_content
+
+    expect(privacy_notice_page.sharing_your_data).to have_header
+    privacy_notice_page.sharing_your_data.assert_content
+
+    expect(privacy_notice_page.receiving_notifications).to have_header
+    privacy_notice_page.receiving_notifications.assert_content
+
+    expect(privacy_notice_page.how_to_complain).to have_header
+    privacy_notice_page.how_to_complain.assert_content
+  end
+
+  scenario "from your representative page" do
+    your_representative_page.load(locale: current_locale_parameter)
+
+    your_representative_page.privacy_notice.click
+
+
+    expect(privacy_notice_page).to be_displayed
+    expect(privacy_notice_page).to have_header
+
+    expect(privacy_notice_page).to have_introduction
+
+    expect(privacy_notice_page.who_manages).to have_header
+    privacy_notice_page.who_manages.assert_content
+
+    expect(privacy_notice_page.personal_data).to have_header
+    privacy_notice_page.personal_data.assert_content
+
+    expect(privacy_notice_page.what_we_do_data).to have_header
+    privacy_notice_page.what_we_do_data.assert_content
+
+    expect(privacy_notice_page.your_rights).to have_header
+    privacy_notice_page.your_rights.assert_content
+
+    expect(privacy_notice_page.sharing_your_data).to have_header
+    privacy_notice_page.sharing_your_data.assert_content
+
+    expect(privacy_notice_page.receiving_notifications).to have_header
+    privacy_notice_page.receiving_notifications.assert_content
+
+    expect(privacy_notice_page.how_to_complain).to have_header
+    privacy_notice_page.how_to_complain.assert_content
+  end
+
+  scenario "from your representative's details page" do
+    your_representatives_details_page.load(locale: current_locale_parameter)
+
+    your_representatives_details_page.privacy_notice.click
+
+
+    expect(privacy_notice_page).to be_displayed
+    expect(privacy_notice_page).to have_header
+
+    expect(privacy_notice_page).to have_introduction
+
+    expect(privacy_notice_page.who_manages).to have_header
+    privacy_notice_page.who_manages.assert_content
+
+    expect(privacy_notice_page.personal_data).to have_header
+    privacy_notice_page.personal_data.assert_content
+
+    expect(privacy_notice_page.what_we_do_data).to have_header
+    privacy_notice_page.what_we_do_data.assert_content
+
+    expect(privacy_notice_page.your_rights).to have_header
+    privacy_notice_page.your_rights.assert_content
+
+    expect(privacy_notice_page.sharing_your_data).to have_header
+    privacy_notice_page.sharing_your_data.assert_content
+
+    expect(privacy_notice_page.receiving_notifications).to have_header
+    privacy_notice_page.receiving_notifications.assert_content
+
+    expect(privacy_notice_page.how_to_complain).to have_header
+    privacy_notice_page.how_to_complain.assert_content
+  end
+
+  scenario "from disability page" do
+    disability_page.load(locale: current_locale_parameter)
+
+    disability_page.privacy_notice.click
+
+
+    expect(privacy_notice_page).to be_displayed
+    expect(privacy_notice_page).to have_header
+
+    expect(privacy_notice_page).to have_introduction
+
+    expect(privacy_notice_page.who_manages).to have_header
+    privacy_notice_page.who_manages.assert_content
+
+    expect(privacy_notice_page.personal_data).to have_header
+    privacy_notice_page.personal_data.assert_content
+
+    expect(privacy_notice_page.what_we_do_data).to have_header
+    privacy_notice_page.what_we_do_data.assert_content
+
+    expect(privacy_notice_page.your_rights).to have_header
+    privacy_notice_page.your_rights.assert_content
+
+    expect(privacy_notice_page.sharing_your_data).to have_header
+    privacy_notice_page.sharing_your_data.assert_content
+
+    expect(privacy_notice_page.receiving_notifications).to have_header
+    privacy_notice_page.receiving_notifications.assert_content
+
+    expect(privacy_notice_page.how_to_complain).to have_header
+    privacy_notice_page.how_to_complain.assert_content
+  end
+
+  scenario "from employer contract claim page" do
+    employers_contract_claim_page.load(locale: current_locale_parameter)
+
+    employers_contract_claim_page.privacy_notice.click
+
+
+    expect(privacy_notice_page).to be_displayed
+    expect(privacy_notice_page).to have_header
+
+    expect(privacy_notice_page).to have_introduction
+
+    expect(privacy_notice_page.who_manages).to have_header
+    privacy_notice_page.who_manages.assert_content
+
+    expect(privacy_notice_page.personal_data).to have_header
+    privacy_notice_page.personal_data.assert_content
+
+    expect(privacy_notice_page.what_we_do_data).to have_header
+    privacy_notice_page.what_we_do_data.assert_content
+
+    expect(privacy_notice_page.your_rights).to have_header
+    privacy_notice_page.your_rights.assert_content
+
+    expect(privacy_notice_page.sharing_your_data).to have_header
+    privacy_notice_page.sharing_your_data.assert_content
+
+    expect(privacy_notice_page.receiving_notifications).to have_header
+    privacy_notice_page.receiving_notifications.assert_content
+
+    expect(privacy_notice_page.how_to_complain).to have_header
+    privacy_notice_page.how_to_complain.assert_content
+  end
+
+  scenario "from additional information page" do
+    additional_information_page.load(locale: current_locale_parameter)
+
+    additional_information_page.privacy_notice.click
+
+
+    expect(privacy_notice_page).to be_displayed
+    expect(privacy_notice_page).to have_header
+
+    expect(privacy_notice_page).to have_introduction
+
+    expect(privacy_notice_page.who_manages).to have_header
+    privacy_notice_page.who_manages.assert_content
+
+    expect(privacy_notice_page.personal_data).to have_header
+    privacy_notice_page.personal_data.assert_content
+
+    expect(privacy_notice_page.what_we_do_data).to have_header
+    privacy_notice_page.what_we_do_data.assert_content
+
+    expect(privacy_notice_page.your_rights).to have_header
+    privacy_notice_page.your_rights.assert_content
+
+    expect(privacy_notice_page.sharing_your_data).to have_header
+    privacy_notice_page.sharing_your_data.assert_content
+
+    expect(privacy_notice_page.receiving_notifications).to have_header
+    privacy_notice_page.receiving_notifications.assert_content
+
+    expect(privacy_notice_page.how_to_complain).to have_header
+    privacy_notice_page.how_to_complain.assert_content
+  end
+
+  scenario "from confirmation of supplied details page" do
+    confirmation_of_supplied_details_page.load(locale: current_locale_parameter)
+
+    confirmation_of_supplied_details_page.privacy_notice.click
+
+
+    expect(privacy_notice_page).to be_displayed
+    expect(privacy_notice_page).to have_header
+
+    expect(privacy_notice_page).to have_introduction
+
+    expect(privacy_notice_page.who_manages).to have_header
+    privacy_notice_page.who_manages.assert_content
+
+    expect(privacy_notice_page.personal_data).to have_header
+    privacy_notice_page.personal_data.assert_content
+
+    expect(privacy_notice_page.what_we_do_data).to have_header
+    privacy_notice_page.what_we_do_data.assert_content
+
+    expect(privacy_notice_page.your_rights).to have_header
+    privacy_notice_page.your_rights.assert_content
+
+    expect(privacy_notice_page.sharing_your_data).to have_header
+    privacy_notice_page.sharing_your_data.assert_content
+
+    expect(privacy_notice_page.receiving_notifications).to have_header
+    privacy_notice_page.receiving_notifications.assert_content
+
+    expect(privacy_notice_page.how_to_complain).to have_header
+    privacy_notice_page.how_to_complain.assert_content
+  end
+
+  scenario "from form submission page" do
+    given_valid_data
+    start_a_new_et3_response
+    answer_respondents_details
+    answer_claimants_details
+    answer_earnings_and_benefits
+    answer_defend_claim_question
+    answer_representative
+    answer_disability_question
+    answer_employers_contract_claim
+    answer_additional_information
+    answer_confirmation_of_supplied_details
+
+    form_submission_page.privacy_notice.click
+
+
+    expect(privacy_notice_page).to be_displayed
+    expect(privacy_notice_page).to have_header
+
+    expect(privacy_notice_page).to have_introduction
+
+    expect(privacy_notice_page.who_manages).to have_header
+    privacy_notice_page.who_manages.assert_content
+
+    expect(privacy_notice_page.personal_data).to have_header
+    privacy_notice_page.personal_data.assert_content
+
+    expect(privacy_notice_page.what_we_do_data).to have_header
+    privacy_notice_page.what_we_do_data.assert_content
+
+    expect(privacy_notice_page.your_rights).to have_header
+    privacy_notice_page.your_rights.assert_content
+
+    expect(privacy_notice_page.sharing_your_data).to have_header
+    privacy_notice_page.sharing_your_data.assert_content
+
+    expect(privacy_notice_page.receiving_notifications).to have_header
+    privacy_notice_page.receiving_notifications.assert_content
+
+    expect(privacy_notice_page.how_to_complain).to have_header
+    privacy_notice_page.how_to_complain.assert_content
+  end
+
+end

--- a/spec/features/access_terms_spec.rb
+++ b/spec/features/access_terms_spec.rb
@@ -5,7 +5,7 @@ RSpec.feature "Access Terms", js: true do
 
   before do
     stub_et_api
-    stub_presigned_url_api_for_s3
+    stub_build_blob_to_azure
   end
 
   scenario "from start page" do
@@ -168,7 +168,7 @@ RSpec.feature "Access Terms", js: true do
     terms_and_conditions_page.disclaimer.assert_content
   end
 
-  scenario "from your representative page" do
+    scenario "from your representative page" do
     your_representative_page.load(locale: current_locale_parameter)
 
     your_representative_page.terms.click

--- a/spec/features/view_footer_spec.rb
+++ b/spec/features/view_footer_spec.rb
@@ -5,73 +5,84 @@ RSpec.feature "View Footer", js: true do
 
   before do
     stub_et_api
-    stub_presigned_url_api_for_s3
+    stub_build_blob_to_azure
   end
 
   scenario "on start page" do
     start_page.load(locale: current_locale_parameter)
 
     expect(start_page).to have_link(t('components.footer.terms'), href: terms_and_conditions_path(locale: current_locale_parameter))
+    expect(start_page).to have_link(t('components.footer.privacy'), href: privacy_notice_path(locale: current_locale_parameter))
   end
 
   scenario "on respondent's details page" do
     respondents_details_page.load(locale: current_locale_parameter)
 
     expect(respondents_details_page).to have_link(t('components.footer.terms'), href: terms_and_conditions_path(locale: current_locale_parameter))
+    expect(respondents_details_page).to have_link(t('components.footer.privacy'), href: privacy_notice_path(locale: current_locale_parameter))
   end
 
   scenario "on claimant's details page" do
     claimants_details_page.load(locale: current_locale_parameter)
 
     expect(claimants_details_page).to have_link(t('components.footer.terms'), href: terms_and_conditions_path(locale: current_locale_parameter))
+    expect(claimants_details_page).to have_link(t('components.footer.privacy'), href: privacy_notice_path(locale: current_locale_parameter))
   end
 
   scenario "on earnings and benefits page" do
     earnings_and_benefits_page.load(locale: current_locale_parameter)
 
     expect(earnings_and_benefits_page).to have_link(t('components.footer.terms'), href: terms_and_conditions_path(locale: current_locale_parameter))
+    expect(earnings_and_benefits_page).to have_link(t('components.footer.privacy'), href: privacy_notice_path(locale: current_locale_parameter))
   end
 
   scenario "on response page" do
     response_page.load(locale: current_locale_parameter)
 
     expect(response_page).to have_link(t('components.footer.terms'), href: terms_and_conditions_path(locale: current_locale_parameter))
+    expect(response_page).to have_link(t('components.footer.privacy'), href: privacy_notice_path(locale: current_locale_parameter))
   end
 
   scenario "on your representative page" do
     your_representative_page.load(locale: current_locale_parameter)
 
     expect(your_representative_page).to have_link(t('components.footer.terms'), href: terms_and_conditions_path(locale: current_locale_parameter))
+    expect(your_representative_page).to have_link(t('components.footer.privacy'), href: privacy_notice_path(locale: current_locale_parameter))
   end
 
   scenario "on your representative's details page" do
     your_representatives_details_page.load(locale: current_locale_parameter)
 
     expect(your_representatives_details_page).to have_link(t('components.footer.terms'), href: terms_and_conditions_path(locale: current_locale_parameter))
+    expect(your_representatives_details_page).to have_link(t('components.footer.privacy'), href: privacy_notice_path(locale: current_locale_parameter))
   end
 
   scenario "on disability page" do
     disability_page.load(locale: current_locale_parameter)
 
     expect(disability_page).to have_link(t('components.footer.terms'), href: terms_and_conditions_path(locale: current_locale_parameter))
+    expect(disability_page).to have_link(t('components.footer.privacy'), href: privacy_notice_path(locale: current_locale_parameter))
   end
 
   scenario "on employer contract claim page" do
     employers_contract_claim_page.load(locale: current_locale_parameter)
 
     expect(employers_contract_claim_page).to have_link(t('components.footer.terms'), href: terms_and_conditions_path(locale: current_locale_parameter))
+    expect(employers_contract_claim_page).to have_link(t('components.footer.privacy'), href: privacy_notice_path(locale: current_locale_parameter))
   end
 
   scenario "on additional information page" do
     additional_information_page.load(locale: current_locale_parameter)
 
     expect(additional_information_page).to have_link(t('components.footer.terms'), href: terms_and_conditions_path(locale: current_locale_parameter))
+    expect(additional_information_page).to have_link(t('components.footer.privacy'), href: privacy_notice_path(locale: current_locale_parameter))
   end
 
   scenario "on confirmation of supplied details page" do
     confirmation_of_supplied_details_page.load(locale: current_locale_parameter)
 
     expect(confirmation_of_supplied_details_page).to have_link(t('components.footer.terms'), href: terms_and_conditions_path(locale: current_locale_parameter))
+    expect(confirmation_of_supplied_details_page).to have_link(t('components.footer.privacy'), href: privacy_notice_path(locale: current_locale_parameter))
   end
 
   scenario "on form submission page" do
@@ -88,6 +99,7 @@ RSpec.feature "View Footer", js: true do
     answer_confirmation_of_supplied_details
 
     expect(form_submission_page).to have_link(t('components.footer.terms'), href: terms_and_conditions_path(locale: current_locale_parameter))
+    expect(form_submission_page).to have_link(t('components.footer.privacy'), href: privacy_notice_path(locale: current_locale_parameter))
   end
 
 end

--- a/spec/support/test_common.rb
+++ b/spec/support/test_common.rb
@@ -1,6 +1,6 @@
 require_relative '../../test_common/capybara'
-require_relative '../../test_common/page_objects'
 require_relative '../../test_common/messaging'
+require_relative '../../test_common/page_objects'
 require_relative '../../test_common/helpers'
 
 RSpec.configure do |c|

--- a/test_common/helpers/pages.rb
+++ b/test_common/helpers/pages.rb
@@ -57,6 +57,10 @@ module ET3
         ET3::Test::TermsAndConditionsPage.new
       end
 
+      def privacy_notice_page
+        ET3::Test::PrivacyNoticePage.new
+      end
+
       # Define other pages here
     end
   end

--- a/test_common/messaging/cy.yml
+++ b/test_common/messaging/cy.yml
@@ -302,6 +302,12 @@ cy:
     form_submission:
       invalid_pdf_download: "Ddim yn barod eto - bydd fersiwn PDF o'ch ffurflen wedi'i llenwi ar gael i'w lawrlwytho maes o law"
       valid_pdf_download: "Mae fersiwn PDF o'ch ffurflen wedi'i llenwi nawr ar gael i'w lawrlwytho"
+    footer:
+      terms_and_conditions_href: telerau ac amodau
+      ico_href: Swyddfa'r Comisiynydd Gwybodaeth
+      personal_info_charter_href: siarter gwybodaeth bersonol
+      using_cookies_href: ddefnyddio cwcis
+      contact_us_href: Cysylltwch â ni
   components:
     save_and_continue_button: "Cadw a pharhau"
     single_choice_option_section:
@@ -321,6 +327,7 @@ cy:
       more_category_href: "http://gov.uk/browse/working"
     footer:
       terms: Telerau ac amodau
+      privacy: Polisi preifatrwydd
     confirmation_of_supplied_details:
       remove_file_link: "Dileu ffeil"
   introduction:
@@ -432,6 +439,55 @@ cy:
             - camliwio twyllodrus
             - unrhyw atebolrwydd arall na ellir ei eithrio neu ei gyfyngu dan y gyfraith berthnasol
         - "%{contact_href} i gael rhagor o wybodaeth."
+  privacy_notice:
+    header: Polisi preifatrwydd
+    introduction: Mae'r polisi preifatrwydd hwn yn egluro pam ein bod yn casglu eich data personol, yr hyn a wnawn ag ef, a'ch hawliau. Mae mwy o wybodaeth am ddefnyddio'r gwasanaeth hwn yn y telerau ac amodau.
+    who_manages:
+      header: Pwy sy'n rheoli'r gwasanaeth hwn
+      content:
+        - Mae'r gwasanaeth hwn yn cael ei reoli gan Wasanaeth Llysoedd a Thribiwnlysoedd ei Mawrhydi (GLlTEM) ac rydym yn gyfrifol am ddiogelu'r data personol a ddarperir gennych.
+        - Mae GLlTEM yn asiantaeth weithredol o'r Weinyddiaeth Cyfiawnder (MoJ). MoJ yw'r rheolydd data ac mae ei %{personal_info_charter_href} yn esbonio mwy am sut maent yn prosesu data personol.
+        - Pan fyddwch yn defnyddio'r gwasanaeth hwn byddwn ni (GLlTEM) yn gofyn ichi ddarparu rhywfaint o ddata personol.
+    personal_data:
+      header: Beth yw'r data personol a gasglwn
+      content:
+        - "Mae'r data personol a gasglwn yn cynnwys:"
+        - - eich enw, cyfeiriad a'ch manylion cyswllt
+          - enw, cyfeiriad a manylion cyswllt eich cynrychiolydd - os oes gennych un
+          - gwybodaeth sy'n dweud wrthym os ydych chi'n agor neges e-bost gennym ni, neu os byddwch yn clicio ar ddolen mewn e-bost
+          - gwybodaeth am sut rydych yn defnyddio'r gwasanaeth hwn, fel eich cyfeiriad IP a'r porwr gwe rydych yn ei ddefnyddio. Rydym yn gwneud hyn drwy %{using_cookies_href}.
+    what_we_do_data:
+      header: Beth rydym yn ei wneud gyda'ch data
+      content:
+        - "Rydym yn casglu eich data personol i:"
+        - - brosesu eich ymateb
+          - bodloni gofynion cyfreithiol
+          - gwneud gwelliannau i'r gwasanaeth hwn
+        - Caiff eich data personol ei brosesu gan ein staff yn y Deyrnas Unedig a chaiff y data ei storio yn y Deyrnas Unedig.
+        - Byddwn yn anfon copi o'ch ymateb at yr hawlydd ac Acas. Byddwn yn rhannu gwybodaeth ar y ffurflen hon â'r Adran Busnes, Ynni a Strategaeth Ddiwydiannol (BEIS) i helpu gyda'u gwaith ymchwil ar dribiwnlysoedd cyflogaeth.
+        - Rydym yn defnyddio Sendgrid i anfon negeseuon e-bost gan ddefnyddio seilwaith rhyngrwyd byd-eang. Ni allwn warantu y bydd negeseuon e-bost yn cael eu cadw yn yr Ardal Economaidd Ewropeaidd (EEA).
+    your_rights:
+      header: Eich hawliau
+      content:
+        - "Gallwch ofyn:"
+        - - i weld y data personol sydd gennym amdanoch
+          - i'r data personol gael ei gywiro
+          - i'r data personol gael ei ddileu (bydd hyn yn dibynnu ar yr amgylchiadau)
+          - bod mynediad at y data personol wedi'i gyfyngu (er enghraifft, gallwch ofyn i'ch data gael ei storio'n hirach a pheidio â chael ei ddileu'n awtomatig)
+        - Anfonwch e-bost atom os ydych eisiau gweld yr wybodaeth hon.
+    sharing_your_data:
+      header: Rhannu eich data
+      content: Rydym yn caniatáu i Google ddefnyddio neu rannu ein data ar gyfer dadansoddi ein gwefan. Cewch wybod am hyn yn ein %{terms_and_conditions_href}.
+    receiving_notifications:
+      header: Derbyn hysbysiadau
+      content:
+        - Fel rhan o'ch ymateb, mae'n bosibl y byddwn yn gofyn a ydych yn dymuno derbyn hysbysiadau gyda diweddariadau. Byddwn yn gofyn am eich enw a’r manylion cyswllt sydd orau gennych.
+        - Gallwch danysgrifio o dderbyn negeseuon testun drwy ddilyn y camau a nodir yn y neges testun. %{contact_us_href} os ydych eisiau canslo diweddariadau e-bost.
+    how_to_complain:
+      header: Sut i gwyno
+      content:
+        - Os ydych eisiau cwyno am sut rydym wedi ymdrin â'ch data personol, anfonwch e-bost atom.
+        - Gallwch gwyno i %{ico_href} os nad ydych yn fodlon â'n hymateb neu'n credu nad ydym yn prosesu eich data personol yn unol â’r gyfraith.
   respondents_details:
     header: "Manylion yr Atebydd"
   claimants_details:

--- a/test_common/messaging/cy.yml
+++ b/test_common/messaging/cy.yml
@@ -308,6 +308,8 @@ cy:
       personal_info_charter_href: siarter gwybodaeth bersonol
       using_cookies_href: ddefnyddio cwcis
       contact_us_href: Cysylltwch â ni
+      privacy_policy_href: polisi preifatrwydd
+      cookie_policy_href: polisi cwcis
   components:
     save_and_continue_button: "Cadw a pharhau"
     single_choice_option_section:
@@ -348,10 +350,6 @@ cy:
     data_content: "Byddwn yn anfon copi o'r ffurflen hon at yr hawlydd a'r Gwasanaeth Cynghori, Cymodi a Chyflafareddu (ACAS). Byddwn yn rhoi'r wybodaeth yr ydych yn ei rhoi inni ar y ffurflen hon ar gyfrifiadur. Mae hyn yn ein helpu i fonitro cynnydd a chynhyrchu ystadegau. Trosglwyddir yr wybodaeth a ddarperir ar y ffurflen hon i'r Adran Busnes, Arloesedd a Sgiliau i gynorthwyo ymchwil i'r defnydd a wneir o dribiwnlysoedd cyflogaeth ac effeithiolrwydd y tribiwnlysoedd hynny."
     start_now: Dechrau nawr
   terms_and_conditions:
-    common:
-      privacy_policy_href: polisi preifatrwydd
-      cookie_policy_href: polisi cwcis
-      contact_href: Cysylltwch â ni
     header: Telerau ac amodau
     introduction: Trwy ddefnyddio’r gwasanaeth hwn rydych yn cytuno i’r telerau defnydd hyn. Mae hyn yn cynnwys y polisi preifatrwydd.
     who_we_are:
@@ -371,19 +369,17 @@ cy:
       header: Deddfau sy’n berthnasol i’r gwasanaeth hwn
       content:
         - "Bydd y defnydd a wnewch o’r gwasanaeth hwn ac unrhyw anghydfod sy’n codi o’i ddefnyddio yn cael eu rheoli a’u dehongli yn unol â chyfreithiau Cymru a Lloegr, gan gynnwys, ond nid yn gyfyngedig i:"
-        - law_bullets:
-            - Deddf Camddefnyddio Cyfrifiaduron 1990
-            - Rheoliadau Cyffredinol Diogelu Data
-            - Deddf Galluedd Meddyliol 2005
+        - - Deddf Camddefnyddio Cyfrifiaduron 1990
+          - Rheoliadau Cyffredinol Diogelu Data
+          - Deddf Galluedd Meddyliol 2005
     how_to_use:
       header: Sut i ddefnyddio’r gwasanaeth hwn yn gyfrifol
       content:
         - Mae peryglon yn gysylltiedig â defnyddio cyfrifiadur sy'n cael ei rannu (e.e. mewn caffi rhyngrwyd), i ddefnyddio’r gwasanaeth hwn. Eich cyfrifoldeb chi yw bod yn ymwybodol o’r peryglon hyn ac osgoi defnyddio unrhyw gyfrifiadur lle mae posibilrwydd y gall eraill weld eich gwybodaeth bersonol. Chi sy’n gyfrifol os ydych chi’n dewis gadael cyfrifiadur heb ei ddiogelu tra byddwch yn defnyddio’r gwasanaeth hwn.
         - "Mae’n rhaid i chi gymryd gofal eich hunan i sicrhau nad yw’r ffordd yr ydych yn cael mynediad at y gwasanaeth hwn yn eich gadael yn agored i’r perygl o:"
-        - risk_bullets:
-            - feirysau
-            - cod cyfrifiadur maleisus
-            - neu ymyrraeth o fath arall a allai achosi difrod i’ch system gyfrifiadurol eich hunan
+        - - feirysau
+          - cod cyfrifiadur maleisus
+          - neu ymyrraeth o fath arall a allai achosi difrod i’ch system gyfrifiadurol eich hunan
         - Ni ddylech gamddefnyddio ein gwasanaeth drwy gyflwyno’n fwriadol firysau, cnafon (trojans), mwydod (worms), bomiau rhesymeg (logic bombs) neu unrhyw ddeunydd arall maleisus neu niweidiol i dechnoleg.
         - Ni ddylech geisio cael mynediad heb awdurdod at y gwasanaeth hwn, y system lle caiff ei storio nac unrhyw weinydd, cyfrifiadur neu gronfa ddata sy’n gysylltiedig ag o. Ni ddylech ymosod ar ein gwefan drwy ymosodiad gwrthod gwasanaeth neu ymosodiad gwrthod gwasanaeth a ddosbarthwyd.
     entering_sensitive_info:
@@ -391,54 +387,49 @@ cy:
       content:
         - Mae’r gwasanaeth ar-lein hwn yn cynnwys nifer o feysydd testun rhydd lle fe’ch gwahoddir i nodi gwybodaeth bersonol sensitif.
         - "Os ydych yn rhoi gwybodaeth am eich:"
-        - information_bullets:
-            - credoau crefyddol
-            - cyfeiriadedd rhywiol neu’ch bywyd rhywiol
-            - tarddiad hiliol neu’ch tarddiad ethnig
-            - barnau gwleidyddol
-            - credoau crefyddol neu’ch credoau athronyddol
-            - aelodaeth undeb lafur
-            - data genetig neu ddata biometrig
-            - gwybodaeth am eich iechyd
+        - - credoau crefyddol
+          - cyfeiriadedd rhywiol neu’ch bywyd rhywiol
+          - tarddiad hiliol neu’ch tarddiad ethnig
+          - barnau gwleidyddol
+          - credoau crefyddol neu’ch credoau athronyddol
+          - aelodaeth undeb lafur
+          - data genetig neu ddata biometrig
+          - gwybodaeth am eich iechyd
         - Rydych yn rhoi eich caniatâd inni ddefnyddio’r wybodaeth hon i ymdrin â’ch cais
         - I gael rhagor o wybodaeth am sut rydym yn casglu a storio eich data personol, gweler y %{privacy_policy_href}.
     disclaimer:
       header: Ymwrthodiad
       content:
         - "Er ein bod yn ymdrechu i gadw gwybodaeth yn gyfredol, nid ydym yn darparu unrhyw warantau, amodau neu sicrwydd y bydd:"
-        - effort_bullets:
-            - yn gyfredol
-            - yn ddiogel
-            - yn gywir
-            - yn gyflawn
-            - yn rhydd o fygiau neu feirysau
+        - - yn gyfredol
+          - yn ddiogel
+          - yn gywir
+          - yn gyflawn
+          - yn rhydd o fygiau neu feirysau
         - Nid ydym yn cyhoeddi cyngor. Dylech gael cyngor proffesiynol neu gyngor arbenigol cyn gwneud unrhyw beth yn seiliedig ar yr wybodaeth yn y gwasanaeth.
         - "Nid ydym yn atebol am unrhyw golled neu ddifrod a all ddeillio o ddefnyddio’r gwasanaeth hwn. Mae hyn yn cynnwys:"
-        - not_liable_bullets:
-            - unrhyw golledion uniongyrchol, anuniongyrchol neu ganlyniadol
-            - unrhyw golled neu ddifrod a achoswyd gan gamweddau sifil (‘tort’, yn cynnwys esgeuluster), torri amodau contract neu fel arall
-            - defnyddio’r gwasanaeth hwn, GOV.UK ac unrhyw wefannau sydd â dolenni i neu o’r gwefan
-            - methu â defnyddio’r gwasanaeth hwn, GOV.UK ac unrhyw wefannau sydd â dolenni i neu o’r gwefan
+        - - unrhyw golledion uniongyrchol, anuniongyrchol neu ganlyniadol
+          - unrhyw golled neu ddifrod a achoswyd gan gamweddau sifil (‘tort’, yn cynnwys esgeuluster), torri amodau contract neu fel arall
+          - defnyddio’r gwasanaeth hwn, GOV.UK ac unrhyw wefannau sydd â dolenni i neu o’r gwefan
+          - methu â defnyddio’r gwasanaeth hwn, GOV.UK ac unrhyw wefannau sydd â dolenni i neu o’r gwefan
         - Mae hyn yn berthnasol os oedd y golled neu’r difrod yn rhagweladwy, wedi codi wrth i’r broses arferol fynd rhagddo, neu os oeddech wedi ein cynghori y gallai ddigwydd.
         - "Mae hyn yn cynnwys, ond nid yw’n gyfyngedig i golli eich:"
-        - loss_bullets:
-            - incwm neu refeniw
-            - cyflog, budd-daliadau neu daliadau eraill
-            - busnes
-            - elw neu gontractau
-            - cyfleoedd
-            - cynilion a ragwelwyd
-            - data
-            - ewyllys da neu’ch enw da
-            - eiddo diriaethol
-            - eiddo anniriaethol, yn cynnwys colled, llygredd neu ddifrod o ddata neu unrhyw system gyfrifiadurol
-            - gwastraff o amser rheolwyr neu amser swyddfa
+        - - incwm neu refeniw
+          - cyflog, budd-daliadau neu daliadau eraill
+          - busnes
+          - elw neu gontractau
+          - cyfleoedd
+          - cynilion a ragwelwyd
+          - data
+          - ewyllys da neu’ch enw da
+          - eiddo diriaethol
+          - eiddo anniriaethol, yn cynnwys colled, llygredd neu ddifrod o ddata neu unrhyw system gyfrifiadurol
+          - gwastraff o amser rheolwyr neu amser swyddfa
         - "Efallai y byddwn yn parhau i fod yn atebol am:"
-        - liable_bullets:
-            - farwolaeth neu anaf personol sy’n codi o’n hesgeuluster
-            - camliwio twyllodrus
-            - unrhyw atebolrwydd arall na ellir ei eithrio neu ei gyfyngu dan y gyfraith berthnasol
-        - "%{contact_href} i gael rhagor o wybodaeth."
+        - - farwolaeth neu anaf personol sy’n codi o’n hesgeuluster
+          - camliwio twyllodrus
+          - unrhyw atebolrwydd arall na ellir ei eithrio neu ei gyfyngu dan y gyfraith berthnasol
+        - "%{contact_us_href} i gael rhagor o wybodaeth."
   privacy_notice:
     header: Polisi preifatrwydd
     introduction: Mae'r polisi preifatrwydd hwn yn egluro pam ein bod yn casglu eich data personol, yr hyn a wnawn ag ef, a'ch hawliau. Mae mwy o wybodaeth am ddefnyddio'r gwasanaeth hwn yn y telerau ac amodau.

--- a/test_common/messaging/en.yml
+++ b/test_common/messaging/en.yml
@@ -310,6 +310,7 @@ en:
       more_category_href: http://gov.uk/browse/working
     footer:
       terms: Terms and conditions
+      privacy: Privacy policy
     confirmation_of_supplied_details:
       remove_file_link: Remove file
   introduction:

--- a/test_common/messaging/en.yml
+++ b/test_common/messaging/en.yml
@@ -297,6 +297,8 @@ en:
       using_cookies_href: using cookies
       contact_us_href: Contact us
       ico_href: Information Commissioner's Office
+      privacy_policy_href: privacy policy
+      cookie_policy_href: cookie policy
   components:
     save_and_continue_button: Save and continue
     single_choice_option_section:
@@ -337,10 +339,6 @@ en:
     data_content: We will send a copy of this form to the claimant and the Advisory, Conciliation and Arbitration Service (ACAS). We will put the information you give us on this form onto a computer. This helps us to monitor progress and produce statistics. Information provided on this form is passed to the Department for Business, Innovation and Skills to assist research into the use and effectiveness of employment tribunals.
     start_now: Start now
   terms_and_conditions:
-    common:
-      privacy_policy_href: privacy policy
-      cookie_policy_href: cookie policy
-      contact_href: Contact us
     header: Terms and conditions
     introduction: By using this service you’re agreeing to these terms of use. This includes the privacy policy.
     who_we_are:
@@ -360,19 +358,17 @@ en:
       header: Laws applying to this service
       content:
         - "Your use of this service and any dispute arising from its use will be governed by and construed in accordance with the laws of England and Wales, including but not limited to the:"
-        - law_bullets:
-            - Computer Misuse Act 1990
-            - General Data Protection Regulations
-            - Mental Capacity Act 2005
+        - - Computer Misuse Act 1990
+          - General Data Protection Regulations
+          - Mental Capacity Act 2005
     how_to_use:
       header: How to use this service responsibly
       content:
         - There are risks in using a shared computer (for example, in a library) to access this service. It’s your responsibility to be aware of these risks and to avoid using any computer which may leave your personal information accessible to others. You’re responsible if you choose to leave a computer unprotected while using this service.
         - "You must take your own precautions to ensure that the way you access this service does not expose you to the risk of:"
-        - risk_bullets:
-            - viruses
-            - malicious computer code
-            - other forms of interference which may damage your computer system
+        - - viruses
+          - malicious computer code
+          - other forms of interference which may damage your computer system
         - You must not misuse this service by knowingly introducing viruses, trojans, worms, logic bombs or other material which is malicious or technologically harmful.
         - You must not attempt to gain unauthorised access to this service, the system on which it is stored, or any server, computer or database connected to it. You must not attack this site using a denial-of-service attack or a distributed denial-of-service attack.
     entering_sensitive_info:
@@ -380,54 +376,49 @@ en:
       content:
         - This online service contains several free-text fields in which you will need to enter information that is personally sensitive.
         - "If you enter information about your:"
-        - information_bullets:
-            - religious beliefs
-            - sexual orientation or sex life
-            - racial or ethnic origins
-            - political opinions
-            - religious or philosophical beliefs
-            - trade union membership
-            - generic data or biometric data
-            - health data
+        - - religious beliefs
+          - sexual orientation or sex life
+          - racial or ethnic origins
+          - political opinions
+          - religious or philosophical beliefs
+          - trade union membership
+          - generic data or biometric data
+          - health data
         - You give us your consent to processing this information for the purpose of dealing with your application
         - For more information about how we collect and store your personal data, see the %{privacy_policy_href}.
     disclaimer:
       header: Disclaimer
       content:
         - "While we make every effort to keep information up to date, we don’t provide any guarantees, conditions or warranties that it will be:"
-        - effort_bullets:
-            - current
-            - secure
-            - accurate
-            - complete
-            - free from bugs or viruses
+        - - current
+          - secure
+          - accurate
+          - complete
+          - free from bugs or viruses
         - We don’t publish advice. You should get professional or specialist advice before doing anything on the basis of the information in the service.
         - "We’re not liable for any loss or damage that may come from using this service. This includes:"
-        - not_liable_bullets:
-            - any direct, indirect or consequential losses
-            - any loss or damage caused by civil wrongs (‘tort’, including negligence), breach of contract or otherwise
-            - use of this service, GOV.UK and any websites that are linked to or from it
-            - the inability to use this service, GOV.UK and any websites that are linked to or from it
+        - - any direct, indirect or consequential losses
+          - any loss or damage caused by civil wrongs (‘tort’, including negligence), breach of contract or otherwise
+          - use of this service, GOV.UK and any websites that are linked to or from it
+          - the inability to use this service, GOV.UK and any websites that are linked to or from it
         - This applies if the loss or damage was foreseeable, arose in the normal course of things or you advised us that it might happen.
         - "This includes (but isn’t limited to) the loss of your:"
-        - loss_bullets:
-            - income or revenue
-            - salary, benefits or other payments
-            - business
-            - profits or contracts
-            - opportunity
-            - anticipated savings
-            - data
-            - goodwill or reputation
-            - tangible property
-            - intangible property, including loss, corruption or damage to data or any computer system
-            - wasted management or office time
+        - - income or revenue
+          - salary, benefits or other payments
+          - business
+          - profits or contracts
+          - opportunity
+          - anticipated savings
+          - data
+          - goodwill or reputation
+          - tangible property
+          - intangible property, including loss, corruption or damage to data or any computer system
+          - wasted management or office time
         - "We may still be liable for:"
-        - liable_bullets:
-            - death or personal injury arising from our negligence
-            - fraudulent misrepresentation
-            - any other liability which cannot be excluded or limited under applicable law
-        - "%{contact_href} for further information"
+        - - death or personal injury arising from our negligence
+          - fraudulent misrepresentation
+          - any other liability which cannot be excluded or limited under applicable law
+        - "%{contact_us_href} for further information"
   privacy_notice:
     header: Privacy policy
     introduction: This privacy policy explains why we collect your personal data, what we do with it, and your rights. More information about using this service is in the terms and conditions.

--- a/test_common/messaging/en.yml
+++ b/test_common/messaging/en.yml
@@ -291,6 +291,12 @@ en:
     form_submission:
       invalid_pdf_download: Not quite ready yet - a PDF version of your completed form will be available for download shortly
       valid_pdf_download: A PDF version of your completed form is now available for download
+    footer:
+      terms_and_conditions_href: terms and conditions
+      personal_info_charter_href: personal information charter
+      using_cookies_href: using cookies
+      contact_us_href: Contact us
+      ico_href: Information Commissioner's Office
   components:
     save_and_continue_button: Save and continue
     single_choice_option_section:
@@ -422,6 +428,55 @@ en:
             - fraudulent misrepresentation
             - any other liability which cannot be excluded or limited under applicable law
         - "%{contact_href} for further information"
+  privacy_notice:
+    header: Privacy policy
+    introduction: This privacy policy explains why we collect your personal data, what we do with it, and your rights. More information about using this service is in the terms and conditions.
+    who_manages:
+      header: Who manages this service
+      content:
+        - This service is managed by Her Majesty’s Courts and Tribunals Service (HMCTS) and we’re responsible for protecting the personal data you provide.
+        - HMCTS is an executive agency of the Ministry of Justice (MoJ). The MoJ is the data controller and their %{personal_info_charter_href} explains more about how they process personal data.
+        - When you use this service we (HMCTS) will ask you to provide some personal data.
+    personal_data:
+      header: What is the personal data that we collect
+      content:
+        - "The personal data we collect includes:"
+        - - your name, address and contact details
+          - your representative’s name, address and contact details - if you have one
+          - information that tells us if you open an email from us, or click on a link in an email
+          - information about how you use this service, like your IP address and the web browser you use. We do this by %{using_cookies_href}.
+    what_we_do_data:
+      header: What we do with your data
+      content:
+        - "We collect your personal data to:"
+        - - process your response
+          - meet legal requirements
+          - make improvements to this service
+        - Your personal data is processed by our staff in the UK and the data is stored in the UK.
+        - We’ll send a copy of your response to the claimant and Acas. We’ll share information provided on this form with the Department for Business, Energy and Industrial Strategy (BEIS) to help with their research on employment tribunals.
+        - We use Sendgrid to send emails using global internet infrastructure. We can’t guarantee that emails will be routed within the European Economic Area (EEA).
+    your_rights:
+      header: Your rights
+      content:
+        - "You can ask:"
+        - - to see the personal data that we hold on you
+          - to have the personal data corrected
+          - to have the personal data removed or deleted (this will depend on the circumstances)
+          - that access to the personal data is restricted (for example, you can ask to have your data stored for longer, and not automatically deleted)
+        - Email if you want to see any of this information.
+    sharing_your_data:
+      header: Sharing your data
+      content: We allow Google to use or share our website analytics data, find out about this in our %{terms_and_conditions_href}.
+    receiving_notifications:
+      header: Receiving notifications
+      content:
+        - As part of your response, we may ask if you want to receive notifications with updates. We’ll ask for your name and preferred contact details.
+        - You can unsubscribe from receiving text messages by following the steps mentioned in the text message. %{contact_us_href} if you want to cancel email updates.
+    how_to_complain:
+      header: How to complain
+      content:
+        - If you want to complain about how we’ve handled your personal data, send an email.
+        - You can complain to the %{ico_href} if you are unsatisfied with our response or believe we are not legally processing your personal data.
   hint:
     respondents_detail:
       contact: For example, John Smith

--- a/test_common/page_objects/base_page.rb
+++ b/test_common/page_objects/base_page.rb
@@ -20,6 +20,7 @@ module ET3
       end
 
       element :terms, :link_named, 'components.footer.terms'
+      element :privacy_notice, :link_named, 'components.footer.privacy'
 
       def js_severe_errors
         return [] unless page.driver.try(:browser).try(:browser) == :chromedriver

--- a/test_common/page_objects/privacy_notice_page.rb
+++ b/test_common/page_objects/privacy_notice_page.rb
@@ -1,0 +1,116 @@
+module ET3
+  module Test
+    class PrivacyNoticePage < BasePage
+      set_url '/privacy'
+      section :switch_language, LanguageSwitcherSection, '.switch-language'
+
+      element :header, :content_header, 'privacy_notice.header'
+
+      element :introduction, :element_with_text, 'privacy_notice.introduction'
+
+      section :who_manages, :wrapper_headered, 'privacy_notice.who_manages.header'do
+        include ET3::Test::I18n
+        element :header, :element_with_text, 'privacy_notice.who_manages.header'
+        def assert_content
+          t('privacy_notice.who_manages.content',
+            personal_info_charter_href: t('links.footer.personal_info_charter_href')
+          ).each do |translated_paragraph|
+            root_element.assert_selector('p', text: translated_paragraph)
+          end
+        end
+      end
+
+      section :personal_data, :wrapper_headered, 'privacy_notice.personal_data.header'do
+        include ET3::Test::I18n
+        element :header, :element_with_text, 'privacy_notice.personal_data.header'
+        def assert_content
+          t('privacy_notice.personal_data.content', using_cookies_href: t('links.footer.using_cookies_href')).each do |translated_element|
+            case translated_element
+            when String
+              root_element.assert_selector('p', text: translated_element)
+            when Array
+              translated_element.each do |translated_bullet_point|
+                root_element.assert_selector('li', text: translated_bullet_point)
+              end
+            end
+          end
+        end
+      end
+
+      section :what_we_do_data, :wrapper_headered, 'privacy_notice.what_we_do_data.header'do
+        include ET3::Test::I18n
+        element :header, :element_with_text, 'privacy_notice.what_we_do_data.header'
+        def assert_content
+          t('privacy_notice.what_we_do_data.content').each do |translated_element|
+            case translated_element
+            when String
+              root_element.assert_selector('p', text: translated_element)
+            when Array
+              translated_element.each do |translated_bullet_point|
+                root_element.assert_selector('li', text: translated_bullet_point)
+              end
+            end
+          end
+        end
+      end
+
+      section :your_rights, :wrapper_headered, 'privacy_notice.your_rights.header'do
+        include ET3::Test::I18n
+        element :header, :element_with_text, 'privacy_notice.your_rights.header'
+        def assert_content
+          t('privacy_notice.your_rights.content').each do |translated_element|
+            case translated_element
+            when String
+            root_element.assert_selector('p', text: translated_element)
+            when Array
+              translated_element.each do |translated_bullet_point|
+                root_element.assert_selector('li', text: translated_bullet_point)
+              end
+            end
+          end
+        end
+      end
+
+      section :sharing_your_data, :wrapper_headered, 'privacy_notice.sharing_your_data.header'do
+        include ET3::Test::I18n
+        element :header, :element_with_text, 'privacy_notice.sharing_your_data.header'
+        def assert_content
+          root_element.assert_selector('p', text: t('privacy_notice.sharing_your_data.content',
+                                       terms_and_conditions_href: t('links.footer.terms_and_conditions_href')))
+        end
+      end
+
+      section :receiving_notifications, :wrapper_headered, 'privacy_notice.receiving_notifications.header'do
+        include ET3::Test::I18n
+        element :header, :element_with_text, 'privacy_notice.receiving_notifications.header'
+        def assert_content
+          t('privacy_notice.receiving_notifications.content',
+            contact_us_href: t('links.footer.contact_us_href')
+          ).each do |translated_element|
+            root_element.assert_selector('p', text: translated_element)
+          end
+        end
+      end
+
+      section :how_to_complain, :wrapper_headered, 'privacy_notice.how_to_complain.header'do
+        include ET3::Test::I18n
+        element :header, :element_with_text, 'privacy_notice.how_to_complain.header'
+        def assert_content
+          t('privacy_notice.how_to_complain.content',
+            ico_href: t('links.footer.ico_href')
+          ).each do |translated_element|
+            root_element.assert_selector('p', text: translated_element)
+          end
+        end
+      end
+
+      def switch_to_welsh
+        switch_language.welsh_link.click
+      end
+
+      def switch_to_english
+        switch_language.english_link.click
+      end
+    end
+  end
+end

--- a/test_common/page_objects/terms_and_conditions_page.rb
+++ b/test_common/page_objects/terms_and_conditions_page.rb
@@ -33,8 +33,8 @@ module ET3
         element :header, :element_with_text, 'terms_and_conditions.sharing_storing_data.header'
         def assert_content
           root_element.assert_selector('p', text: t('terms_and_conditions.sharing_storing_data.content',
-                                                    privacy_policy_href: t('terms_and_conditions.common.privacy_policy_href'),
-                                                    cookie_policy_href: t('terms_and_conditions.common.cookie_policy_href')
+                                                    privacy_policy_href: t('links.footer.privacy_policy_href'),
+                                                    cookie_policy_href: t('links.footer.cookie_policy_href')
           ))
         end
       end
@@ -47,8 +47,8 @@ module ET3
             case translated_element
             when String
               root_element.assert_selector('p', text: translated_element)
-            when Hash
-              translated_element.values.flatten.each do |translated_bullet_point|
+            when Array
+              translated_element.each do |translated_bullet_point|
                 root_element.assert_selector('li', text: translated_bullet_point)
               end
             end
@@ -64,8 +64,8 @@ module ET3
             case translated_element
             when String
               root_element.assert_selector('p', text: translated_element)
-            when Hash
-              translated_element.values.flatten.each do |translated_bullet_point|
+            when Array
+              translated_element.each do |translated_bullet_point|
                 root_element.assert_selector('li', text: translated_bullet_point)
               end
             end
@@ -78,13 +78,13 @@ module ET3
         element :header, :element_with_text, 'terms_and_conditions.entering_sensitive_info.header'
         def assert_content
           t('terms_and_conditions.entering_sensitive_info.content',
-            privacy_policy_href: t('terms_and_conditions.common.privacy_policy_href')
+            privacy_policy_href: t('links.footer.privacy_policy_href')
           ).each do |translated_element|
             case translated_element
             when String
               root_element.assert_selector('p', text: translated_element)
-            when Hash
-              translated_element.values.flatten.each do |translated_bullet_point|
+            when Array
+              translated_element.each do |translated_bullet_point|
                 root_element.assert_selector('li', text: translated_bullet_point)
               end
             end
@@ -97,13 +97,13 @@ module ET3
         element :header, :element_with_text, 'terms_and_conditions.disclaimer.header'
         def assert_content
           t('terms_and_conditions.disclaimer.content',
-            contact_href: t('terms_and_conditions.common.contact_href')
+            contact_us_href: t('links.footer.contact_us_href')
           ).each do |translated_element|
             case translated_element
             when String
               root_element.assert_selector('p', text: translated_element)
-            when Hash
-              translated_element.values.flatten.each do |translated_bullet_point|
+            when Array
+              translated_element.each do |translated_bullet_point|
                 root_element.assert_selector('li', text: translated_bullet_point)
               end
             end


### PR DESCRIPTION
Merging back into the Terms & Conditions branch as I will release the entire footer/legal pages in one go.

After building the Privacy Notice I realised I had an opportunity to tidy up some rubbish code in the Terms branch. I have now removed the hashes from the `en` and `cy` yaml files and used arrays for bullet points instead.