### PR TITLE
RST-1754: Add Cookies Page to Footer

### DIFF
--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -3,7 +3,9 @@ class StaticPagesController < ApplicationController
 
   def expired; end
 
-  def terms; end
+  def cookies; end
 
   def privacy; end
+
+  def terms; end
 end

--- a/app/views/shared/_footer_links.html.slim
+++ b/app/views/shared/_footer_links.html.slim
@@ -1,3 +1,5 @@
 ul
-  li= link_to(t('components.footer.terms'), terms_and_conditions_path)
+  li= link_to(t('components.footer.cookies'), cookies_path)
   li= link_to(t('components.footer.privacy'), privacy_notice_path)
+  li= link_to(t('components.footer.terms'), terms_and_conditions_path)
+

--- a/app/views/static_pages/cookies.html.slim
+++ b/app/views/static_pages/cookies.html.slim
@@ -4,15 +4,18 @@
 
   p = t('components.cookies.introduction')
   = render 'static_pages/policy_elements', translated_content_array: t('components.cookies.introduction_bullets',
-          managing_cookies_href: link_to(t('components.cookies.managing_cookies_href'), 'http://www.aboutcookies.org/'))
+          managing_cookies_href: link_to(t('components.cookies.managing_cookies_href'),
+                  'http://www.aboutcookies.org/', target: :_blank))
 
   h3.heading-small = t('components.cookies.subheader')
 
   #website-usage
     h4.heading-small = t('components.cookies.website_usage.header')
     = render 'static_pages/policy_elements', translated_content_array: t('components.cookies.website_usage.content',
-            google_privacy_policy_href: link_to(t('components.cookies.google_privacy_policy_href'), 'https://www.google.com/policies/privacy/partners/'),
-            opt_out_href: link_to(t('components.cookies.opt_out_href'), 'https://tools.google.com/dlpage/gaoptout'))
+            google_privacy_policy_href: link_to(t('components.cookies.google_privacy_policy_href'),
+                    'https://www.google.com/policies/privacy/partners/', target: :_blank),
+            opt_out_href: link_to(t('components.cookies.opt_out_href'),
+                    'https://tools.google.com/dlpage/gaoptout', target: :_blank))
     table
       thead
         tr

--- a/app/views/static_pages/cookies.html.slim
+++ b/app/views/static_pages/cookies.html.slim
@@ -1,0 +1,62 @@
+- content_for :form_page_title, t('components.cookies.header')
+- content_for :page_title, raw("#{content_for :form_page_title} - Response to Claim - MoJ")
+.content-body.cookies
+
+  p = t('components.cookies.introduction')
+  = render 'static_pages/policy_elements', translated_content_array: t('components.cookies.introduction_bullets',
+          managing_cookies_href: link_to(t('components.cookies.managing_cookies_href'), 'http://www.aboutcookies.org/'))
+
+  h3.heading-small = t('components.cookies.subheader')
+
+  #website-usage
+    h4.heading-small = t('components.cookies.website_usage.header')
+    = render 'static_pages/policy_elements', translated_content_array: t('components.cookies.website_usage.content',
+            google_privacy_policy_href: link_to(t('components.cookies.google_privacy_policy_href'), 'https://www.google.com/policies/privacy/partners/'),
+            opt_out_href: link_to(t('components.cookies.opt_out_href'), 'https://tools.google.com/dlpage/gaoptout'))
+    table
+      thead
+        tr
+          th = t('components.cookies.table_header.name')
+          th = t('components.cookies.table_header.purpose')
+          th = t('components.cookies.table_header.expires')
+      tbody
+        - t('components.cookies.website_usage.table').each do |row|
+          tr
+            - row.each do |cell|
+              td = cell
+  br
+  #introductory-message
+    h4.heading-small = t('components.cookies.introductory_message.header')
+    p = t('components.cookies.introductory_message.content')
+
+    table
+      thead
+        tr
+          th = t('components.cookies.table_header.name')
+          th = t('components.cookies.table_header.purpose')
+          th = t('components.cookies.table_header.expires')
+      tbody
+        tr
+          td = t('components.cookies.introductory_message.table.name')
+          td = t('components.cookies.introductory_message.table.purpose')
+          td = t('components.cookies.introductory_message.table.expires')
+  br
+  #store-answers
+    h4.heading-small = t('components.cookies.store_answers.header')
+    p = t('components.cookies.store_answers.content')
+
+    table
+      thead
+        tr
+          th = t('components.cookies.table_header.name')
+          th = t('components.cookies.table_header.purpose')
+          th = t('components.cookies.table_header.expires')
+      tbody
+        tr
+          td = t('components.cookies.store_answers.table.name')
+          td = t('components.cookies.store_answers.table.purpose')
+          td = t('components.cookies.store_answers.table.expires')
+  br
+  #more-secure
+    h4.heading-small = t('components.cookies.more_secure.header')
+    p = t('components.cookies.more_secure.content')

--- a/app/views/static_pages/privacy.html.slim
+++ b/app/views/static_pages/privacy.html.slim
@@ -3,18 +3,23 @@
 .content-body.privacy-notice
 
   p = t('components.privacy_notice.introduction',
-          terms_and_conditions_href: link_to(t('components.privacy_notice.terms_and_conditions_href'), terms_and_conditions_path)).html_safe
+          terms_and_conditions_href: link_to(t('components.privacy_notice.terms_and_conditions_href'),
+                  terms_and_conditions_path, target: :_blank)).html_safe
 
   #who-manages-service
     h4.heading-small = t('components.privacy_notice.who_manages.header')
     - t('components.privacy_notice.who_manages.content',
-    personal_info_charter_href: link_to(t('components.privacy_notice.personal_info_charter_href'), 'https://www.gov.uk/government/organisations/ministry-of-justice/about/personal-information-charter')).each do |paragraph|
+    personal_info_charter_href: link_to(t('components.privacy_notice.personal_info_charter_href'),
+            'https://www.gov.uk/government/organisations/ministry-of-justice/about/personal-information-charter',
+            target: :_blank)).each do |paragraph|
       p = paragraph.html_safe
 
   #personal-data
     h4.heading-small = t('components.privacy_notice.personal_data.header')
-    = render 'static_pages/policy_elements', translated_content_array: t('components.privacy_notice.personal_data.content',
-            using_cookies_href: link_to(t('components.privacy_notice.using_cookies_href'), 'http://www.aboutcookies.org.uk/managing-cookies'))
+    = render 'static_pages/policy_elements',
+            translated_content_array: t('components.privacy_notice.personal_data.content',
+            using_cookies_href: link_to(t('components.privacy_notice.using_cookies_href'),
+                    'http://www.aboutcookies.org.uk/managing-cookies', target: :_blank))
 
   #what-we-do-data
     h4.heading-small = t('components.privacy_notice.what_we_do_data.header')
@@ -26,17 +31,22 @@
 
   #sharing-your-data
     h4.heading-small = t('components.privacy_notice.sharing_your_data.header')
-    p = t('components.privacy_notice.sharing_your_data.content', terms_and_conditions_href: link_to(t('components.privacy_notice.terms_and_conditions_href'), terms_and_conditions_path)).html_safe
+    p = t('components.privacy_notice.sharing_your_data.content',
+            terms_and_conditions_href: link_to(t('components.privacy_notice.terms_and_conditions_href'),
+                    terms_and_conditions_path, target: :_blank)).html_safe
 
   #receiving-notifications
     h4.heading-small = t('components.privacy_notice.receiving_notifications.header')
-    - t('components.privacy_notice.receiving_notifications.content', contact_us_href: link_to(t('components.privacy_notice.receiving_notifications.contact_us_href'), '#')).each do |paragraph|
+    - t('components.privacy_notice.receiving_notifications.content',
+            contact_us_href: link_to(t('components.privacy_notice.receiving_notifications.contact_us_href'),
+                    'https://www.gov.uk/guidance/employment-tribunal-offices-and-venues',
+                    target: :_blank)).each do |paragraph|
       p = paragraph.html_safe
 
   #how-to-complain
     h4.heading-small = t('components.privacy_notice.how_to_complain.header')
     - t('components.privacy_notice.how_to_complain.content',
             ico_href: link_to(t('components.privacy_notice.how_to_complain.ico_href'),
-                    'https://ico.org.uk/global/contact-us')).each do |paragraph|
+                    'https://ico.org.uk/global/contact-us', target: :_blank)).each do |paragraph|
       p = paragraph.html_safe
 

--- a/app/views/static_pages/terms.html.slim
+++ b/app/views/static_pages/terms.html.slim
@@ -3,7 +3,8 @@
 .content-body.terms-conditions
 
   p = t('components.terms_and_conditions.introduction',
-          privacy_policy_href: link_to(t('components.terms_and_conditions.privacy_policy_href'), privacy_notice_path)).html_safe
+          privacy_policy_href: link_to(t('components.terms_and_conditions.privacy_policy_href'),
+                  privacy_notice_path, target: :_blank)).html_safe
 
   #who-we-are
     h4.heading-small = t('components.terms_and_conditions.who_we_are.header')
@@ -18,8 +19,10 @@
   #sharing-storing-data
     h4.heading-small = t('components.terms_and_conditions.sharing_storing_data.header')
     p = t('components.terms_and_conditions.sharing_storing_data.content',
-            privacy_policy_href: link_to(t('components.terms_and_conditions.privacy_policy_href'), privacy_notice_path),
-            cookie_policy_href: link_to(t('components.terms_and_conditions.cookie_policy_href'), '#')).html_safe
+            privacy_policy_href: link_to(t('components.terms_and_conditions.privacy_policy_href'),
+                    privacy_notice_path, target: :_blank),
+            cookie_policy_href: link_to(t('components.terms_and_conditions.cookie_policy_href'),
+                    cookies_path, target: :_blank)).html_safe
 
   #laws-applying-service
     h4.heading-small = t('components.terms_and_conditions.laws_applied.header')
@@ -31,10 +34,14 @@
 
   #entering-personally-sensitive-information
     h4.heading-small = t('components.terms_and_conditions.entering_sensitive_info.header')
-    = render 'static_pages/policy_elements', translated_content_array: t('components.terms_and_conditions.entering_sensitive_info.content',
-            privacy_policy_href: link_to(t('components.terms_and_conditions.privacy_policy_href'), privacy_notice_path))
+    = render 'static_pages/policy_elements',
+            translated_content_array: t('components.terms_and_conditions.entering_sensitive_info.content',
+            privacy_policy_href: link_to(t('components.terms_and_conditions.privacy_policy_href'),
+                    privacy_notice_path, target: :_blank))
 
   #disclaimer
     h4.heading-small = t('components.terms_and_conditions.disclaimer.header')
-    = render 'static_pages/policy_elements', translated_content_array: t('components.terms_and_conditions.disclaimer.content',
-            contact_href: link_to(t('components.terms_and_conditions.contact_href'), '#'))
+    = render 'static_pages/policy_elements',
+            translated_content_array: t('components.terms_and_conditions.disclaimer.content',
+            contact_href: link_to(t('components.terms_and_conditions.contact_href'),
+                    'https://www.gov.uk/guidance/employment-tribunal-offices-and-venues', target: :_blank))

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -1,4 +1,4 @@
-# Files in the config/locales directory are used for internationalization
+  # Files in the config/locales directory are used for internationalization
 # and are automatically loaded by Rails. If you want to use locales other
 # than English, add the necessary files in this directory.
 #
@@ -299,6 +299,7 @@ cy:
     footer:
       terms: Telerau ac amodau
       privacy: Polisi preifatrwydd
+      cookies: Cwcis
     confirmation_of_supplied_details:
       header: "Cadarnhau'r manylion a roddwyd "
       receipt_header: E-bost yn cadarnhau bod y manylion wedi'u hanfon
@@ -365,6 +366,62 @@ cy:
       data_title: "Deddf Diogelu Data 1998 "
       data_content: "Byddwn yn anfon copi o'r ffurflen hon at yr hawlydd a'r Gwasanaeth Cynghori, Cymodi a Chyflafareddu (ACAS). Byddwn yn rhoi'r wybodaeth yr ydych yn ei rhoi inni ar y ffurflen hon ar gyfrifiadur. Mae hyn yn ein helpu i fonitro cynnydd a chynhyrchu ystadegau. Trosglwyddir yr wybodaeth a ddarperir ar y ffurflen hon i'r Adran Busnes, Arloesedd a Sgiliau i gynorthwyo ymchwil i'r defnydd a wneir o dribiwnlysoedd cyflogaeth ac effeithiolrwydd y tribiwnlysoedd hynny."
       start_now: Dechrau nawr
+    cookies:
+      header: Cwcis
+      managing_cookies_href: su i reoli cwcis
+      google_privacy_policy_href: Polisi Preifatrwydd
+      opt_out_href: optio allan o Google Analytics
+      introduction: "Darn bach o ddata sy'n cael ei storio ar eich cyfrifiadur, eich tabled neu eich ffôn pan fyddwch yn ymweld â gwefan yw Cwci. Mae angen cwcis ar y rhan fwyaf o wefannau i weithio'n iawn."
+      introduction_bullets:
+        - "Mae’r gwasanaeth hwn yn eu defnyddio i:"
+        - - fesur sut rydych yn defnyddio’r gwasanaeth hwn fel y gallwn ei wella
+          - cofio'r hysbysiadau rydych wedi'u gweld fel na fyddwch yn eu gweld eto
+          - storio’r atebion a roddwch dros dro
+        - Am ragor o wybodaeth, gweler %{managing_cookies_href}
+      subheader: Sut mae cwcis yn cael eu defnyddio yn y gwasanaeth hwn
+      website_usage:
+        header: 1. I fesur faint o bobl sy’n defnyddio ein gwefan
+        content:
+          - Rydym yn defnyddio meddalwedd Google Analytics i gasglu gwybodaeth am sut rydych yn defnyddio'r gwasanaeth hwn. Gwnawn hyn i helpu i sicrhau bod y gwasanaeth yn diwallu anghenion ei ddefnyddwyr ac i'n helpu i wneud gwelliannau, er enghraifft gwella’r cyfleuster chwilio.
+          - "Mae Google Analytics yn storio gwybodaeth am:"
+          - - y tudalennau yr ydych yn ymweld â hwy
+            - faint o amser y byddwch yn ei dreulio ar bob tudalen
+            - sut y daethoch o hyd i’r gwasanaeth
+            - yr hyn rydych chi'n clicio arno wrth ymweld â'r gwasanaeth
+          - Rydym yn caniatáu i Google ddefnyddio neu rannu ein data dadansoddi. Gallwch ddarganfod mwy am sut mae Google yn defnyddio’r wybodaeth hon yn eu %{google_privacy_policy_href}.
+          - Gallwch %{opt_out_href} os nad ydych am i Google gael mynediad at eich gwybodaeth.
+          - "Mae Google Analytics yn gosod y cwcis canlynol:"
+        table:
+          - - "_ga"
+            - Mae hyn yn ein helpu i gyfrif faint o bobl sy'n ymweld â'r gwasanaeth drwy olrhain os ydych wedi ymweld o'r blaen
+            - 2 flynedd
+          - - "_gat"
+            - Rheoli faint o bobl sy’n ymweld â’r dudalen
+            - 10 munud
+          - - "_gid"
+            - Eich cyfeirio at y gwasanaeth
+            - 24 awr
+      introductory_message:
+        header: 2. Troi ein neges gyflwyno i ffwrdd
+        content: Efallai y byddwch yn gweld neges groeso pan fyddwch yn ymweld â'r gwasanaeth am y tro cyntaf. Byddwn yn storio cwcis fel bod eich cyfrifiadur yn gwybod eich bod wedi ei gweld ac yn gwybod i beidio â'i dangos eto.
+        table:
+          name: "seen_cookie_messages"
+          purpose: "Arbed neges i roi gwybod inni eich bod wedi gweld ein neges ynglŷn â chwcis"
+          expires: 1 mis
+      store_answers:
+        header: 3. Storio’r atebion a roesoch yn ystod eich ymweliad (gelwir hyn yn ‘sesiwn’)
+        content: Caiff cwcis sesiwn eu storio ar eich cyfrifiadur wrth ichi fynd drwy wefan, ac maent yn gadael i'r wefan wybod beth rydych wedi'i weld a'i wneud hyd yn hyn. Cwcis dros dro yw'r rhain ac fe'u dilëir yn awtomatig ychydig amser ar ôl ichi adael y wefan.
+        table:
+          name: "_et3_session"
+          purpose: Cysylltu eich sesiwn â’ch atebion
+          expires: Pan fyddwch yn cau eich porwr
+      more_secure:
+        header: 4. Gwneud y gwasanaeth yn fwy diogel
+        content: Rydym yn gosod cwcis er mwyn rhwystro hacwyr rhag addasu cynnwys y cwcis eraill a osodon ni. Mae hyn yn gwneud y gwasanaeth yn fwy diogel ac yn diogelu eich gwybodaeth bersonol.
+      table_header:
+        name: Enw
+        purpose: Pwrpas
+        expires: Dod i ben
     terms_and_conditions:
       header: Telerau ac amodau
       introduction: Trwy ddefnyddio’r gwasanaeth hwn rydych yn cytuno i’r telerau defnydd hyn. Mae hyn yn cynnwys y %{privacy_policy_href}.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -370,6 +370,62 @@ en:
       data_title: Data Protection Act 1998
       data_content: We will send a copy of this form to the claimant and the Advisory, Conciliation and Arbitration Service (ACAS). We will put the information you give us on this form onto a computer. This helps us to monitor progress and produce statistics. Information provided on this form is passed to the Department for Business, Innovation and Skills to assist research into the use and effectiveness of employment tribunals.
       start_now: Start now
+    cookies:
+      header: Cookies
+      managing_cookies_href: how to manage cookies
+      google_privacy_policy_href: Privacy Policy
+      opt_out_href: opt out of Google Analytics
+      introduction: A cookie is a small piece of data that’s stored on your computer, tablet, or phone when you visit a website. Most websites need cookies to work properly.
+      introduction_bullets:
+        - "This service uses them to:"
+        - - measure how you use the service so it can be improved
+          - remember the notifications you’ve seen so that you’re not shown them again
+          - temporarily store the answers you give
+        - Find out more about %{managing_cookies_href}
+      subheader: How cookies are used in this service
+      website_usage:
+        header: 1. To measure website usage
+        content:
+          - We use Google Analytics software to collect information about how you use this service. We do this to help make sure the service is meeting the needs of its users and to help us make improvements, for example improving site search.
+          - "Google Analytics stores information about:"
+          - - the pages you visit
+            - how long you spend on each page
+            - how you got to the service
+            - what you click on while you're visiting the service
+          - We allow Google to use or share our analytics data. You can find out more about how Google use this information in their %{google_privacy_policy_href}.
+          - You can %{opt_out_href} if you do not want Google to have access to your information.
+          - "Google Analytics sets the following cookies:"
+        table:
+          - - "_ga"
+            - This helps us count how many people visit the service by tracking if you’ve visited before
+            - 2 years
+          - - "_gat"
+            - Manages the rate page view requests are made
+            - 10 minutes
+          - - "_gid"
+            - Identifies you to the service
+            - 24 hours
+      introductory_message:
+        header: 2. To turn our introductory message off
+        content: You may see a pop-up welcome message when you first visit the service. We’ll store a cookie so that your computer knows you’ve seen it and knows not to show it again.
+        table:
+          name: "seen_cookie_messages"
+          purpose: "Saves a message to let us know that you’ve seen our cookie message"
+          expires: 1 month
+      store_answers:
+        header: 3. To store the answers you’ve given during your visit (known as a ‘session’)
+        content: Session cookies are stored on your computer as you travel through a website, and let the website know what you’ve seen and done so far. These are temporary cookies and are automatically deleted a short while after you leave the website.
+        table:
+          name: "_et3_session"
+          purpose: Temporarily links your session to your answers
+          expires: When you close your browser
+      more_secure:
+        header: 4. To make the service more secure
+        content: We set cookies which prevent attackers from modifying the contents of the other cookies we set. This makes the service more secure and protects your personal information.
+      table_header:
+        name: Name
+        purpose: Purpose
+        expires: Expires
     terms_and_conditions:
       header: Terms and conditions
       introduction: By using this service you’re agreeing to these terms of use. This includes the %{privacy_policy_href}.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -301,8 +301,9 @@ en:
       more_category_link: More from the Working, jobs and pensions category
       more_category_href: http://gov.uk/browse/working
     footer:
-      terms: Terms and conditions
       privacy: Privacy policy
+      terms: Terms and conditions
+      cookies: Cookies
     confirmation_of_supplied_details:
       header: Confirmation of Supplied Details
       receipt_header: Email Receipt

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,6 +15,7 @@ Rails.application.routes.draw do
     end
     get "/terms" => 'static_pages#terms', as: 'terms_and_conditions'
     get "/privacy" => 'static_pages#privacy', as: 'privacy_notice'
+    get "/cookies" => 'static_pages#cookies'
     root 'static_pages#index'
     delete "/respond/confirmation_of_supplied_details/remove_rtf" => 'confirmation_of_supplied_details#destroy_rtf', as: :remove_rtf
     mount EtDropzoneUploader::Engine, at: '/api/v2/build_blob'

--- a/spec/features/access_cookies_spec.rb
+++ b/spec/features/access_cookies_spec.rb
@@ -8,323 +8,35 @@ RSpec.feature "Access Cookies", js: true do
     stub_build_blob_to_azure
   end
 
-  scenario "from start page" do
-    start_page.load(locale: current_locale_parameter)
+  shared_examples "on a per-page basis" do
+    scenario "will show page content" do
+      current_page.load(locale: current_locale_parameter)
 
-    start_page.cookies.click
+      current_page.cookies.click
 
-    expect(cookies_page).to be_displayed
-    expect(cookies_page).to have_header
+      expect(cookies_page).to be_displayed
+      expect(cookies_page).to have_header
 
-    expect(cookies_page).to have_introduction
-    cookies_page.introduction.assert_content
+      expect(cookies_page).to have_introduction
+      cookies_page.introduction.assert_content
 
-    expect(cookies_page).to have_cookies_used_subheader
+      expect(cookies_page).to have_cookies_used_subheader
 
-    expect(cookies_page.website_usage).to have_header
-    cookies_page.website_usage.assert_content
-    cookies_page.website_usage.assert_table
+      expect(cookies_page.website_usage).to have_header
+      cookies_page.website_usage.assert_content
+      cookies_page.website_usage.assert_table
 
-    expect(cookies_page.introductory_message).to have_header
-    cookies_page.introductory_message.assert_content
-    cookies_page.introductory_message.assert_table
+      expect(cookies_page.introductory_message).to have_header
+      cookies_page.introductory_message.assert_content
+      cookies_page.introductory_message.assert_table
 
-    expect(cookies_page.store_answers).to have_header
-    cookies_page.store_answers.assert_content
-    cookies_page.store_answers.assert_table
+      expect(cookies_page.store_answers).to have_header
+      cookies_page.store_answers.assert_content
+      cookies_page.store_answers.assert_table
 
-    expect(cookies_page.more_secure).to have_header
-    cookies_page.more_secure.assert_content
-  end
-
-  scenario "from respondent's details page" do
-    respondents_details_page.load(locale: current_locale_parameter)
-
-    respondents_details_page.cookies.click
-
-    expect(cookies_page).to be_displayed
-    expect(cookies_page).to have_header
-
-    expect(cookies_page).to have_introduction
-    cookies_page.introduction.assert_content
-
-    expect(cookies_page).to have_cookies_used_subheader
-
-    expect(cookies_page.website_usage).to have_header
-    cookies_page.website_usage.assert_content
-    cookies_page.website_usage.assert_table
-
-    expect(cookies_page.introductory_message).to have_header
-    cookies_page.introductory_message.assert_content
-    cookies_page.introductory_message.assert_table
-
-    expect(cookies_page.store_answers).to have_header
-    cookies_page.store_answers.assert_content
-    cookies_page.store_answers.assert_table
-
-    expect(cookies_page.more_secure).to have_header
-    cookies_page.more_secure.assert_content
-  end
-
-  scenario "from claimant's details page" do
-    claimants_details_page.load(locale: current_locale_parameter)
-
-    claimants_details_page.cookies.click
-
-    expect(cookies_page).to be_displayed
-    expect(cookies_page).to have_header
-
-    expect(cookies_page).to have_introduction
-    cookies_page.introduction.assert_content
-
-    expect(cookies_page).to have_cookies_used_subheader
-
-    expect(cookies_page.website_usage).to have_header
-    cookies_page.website_usage.assert_content
-    cookies_page.website_usage.assert_table
-
-    expect(cookies_page.introductory_message).to have_header
-    cookies_page.introductory_message.assert_content
-    cookies_page.introductory_message.assert_table
-
-    expect(cookies_page.store_answers).to have_header
-    cookies_page.store_answers.assert_content
-    cookies_page.store_answers.assert_table
-
-    expect(cookies_page.more_secure).to have_header
-    cookies_page.more_secure.assert_content
-  end
-
-  scenario "from earnings and benefits page" do
-    earnings_and_benefits_page.load(locale: current_locale_parameter)
-
-    earnings_and_benefits_page.cookies.click
-
-    expect(cookies_page).to be_displayed
-    expect(cookies_page).to have_header
-
-    expect(cookies_page).to have_introduction
-    cookies_page.introduction.assert_content
-
-    expect(cookies_page).to have_cookies_used_subheader
-
-    expect(cookies_page.website_usage).to have_header
-    cookies_page.website_usage.assert_content
-    cookies_page.website_usage.assert_table
-
-    expect(cookies_page.introductory_message).to have_header
-    cookies_page.introductory_message.assert_content
-    cookies_page.introductory_message.assert_table
-
-    expect(cookies_page.store_answers).to have_header
-    cookies_page.store_answers.assert_content
-    cookies_page.store_answers.assert_table
-
-    expect(cookies_page.more_secure).to have_header
-    cookies_page.more_secure.assert_content
-  end
-
-  scenario "from response page" do
-    response_page.load(locale: current_locale_parameter)
-
-    response_page.cookies.click
-
-    expect(cookies_page).to be_displayed
-    expect(cookies_page).to have_header
-
-    expect(cookies_page).to have_introduction
-    cookies_page.introduction.assert_content
-
-    expect(cookies_page).to have_cookies_used_subheader
-
-    expect(cookies_page.website_usage).to have_header
-    cookies_page.website_usage.assert_content
-    cookies_page.website_usage.assert_table
-
-    expect(cookies_page.introductory_message).to have_header
-    cookies_page.introductory_message.assert_content
-    cookies_page.introductory_message.assert_table
-
-    expect(cookies_page.store_answers).to have_header
-    cookies_page.store_answers.assert_content
-    cookies_page.store_answers.assert_table
-
-    expect(cookies_page.more_secure).to have_header
-    cookies_page.more_secure.assert_content
-  end
-
-  scenario "from your representative page" do
-    your_representative_page.load(locale: current_locale_parameter)
-
-    your_representative_page.cookies.click
-
-    expect(cookies_page).to be_displayed
-    expect(cookies_page).to have_header
-
-    expect(cookies_page).to have_introduction
-    cookies_page.introduction.assert_content
-
-    expect(cookies_page).to have_cookies_used_subheader
-
-    expect(cookies_page.website_usage).to have_header
-    cookies_page.website_usage.assert_content
-    cookies_page.website_usage.assert_table
-
-    expect(cookies_page.introductory_message).to have_header
-    cookies_page.introductory_message.assert_content
-    cookies_page.introductory_message.assert_table
-
-    expect(cookies_page.store_answers).to have_header
-    cookies_page.store_answers.assert_content
-    cookies_page.store_answers.assert_table
-
-    expect(cookies_page.more_secure).to have_header
-    cookies_page.more_secure.assert_content
-  end
-
-  scenario "from your representative's details page" do
-    your_representatives_details_page.load(locale: current_locale_parameter)
-
-    your_representatives_details_page.cookies.click
-
-    expect(cookies_page).to be_displayed
-    expect(cookies_page).to have_header
-
-    expect(cookies_page).to have_introduction
-    cookies_page.introduction.assert_content
-
-    expect(cookies_page).to have_cookies_used_subheader
-
-    expect(cookies_page.website_usage).to have_header
-    cookies_page.website_usage.assert_content
-    cookies_page.website_usage.assert_table
-
-    expect(cookies_page.introductory_message).to have_header
-    cookies_page.introductory_message.assert_content
-    cookies_page.introductory_message.assert_table
-
-    expect(cookies_page.store_answers).to have_header
-    cookies_page.store_answers.assert_content
-    cookies_page.store_answers.assert_table
-
-    expect(cookies_page.more_secure).to have_header
-    cookies_page.more_secure.assert_content
-  end
-
-  scenario "from disability page" do
-    disability_page.load(locale: current_locale_parameter)
-
-    disability_page.cookies.click
-
-    expect(cookies_page).to be_displayed
-    expect(cookies_page).to have_header
-
-    expect(cookies_page).to have_introduction
-    cookies_page.introduction.assert_content
-
-    expect(cookies_page).to have_cookies_used_subheader
-
-    expect(cookies_page.website_usage).to have_header
-    cookies_page.website_usage.assert_content
-    cookies_page.website_usage.assert_table
-
-    expect(cookies_page.introductory_message).to have_header
-    cookies_page.introductory_message.assert_content
-    cookies_page.introductory_message.assert_table
-
-    expect(cookies_page.store_answers).to have_header
-    cookies_page.store_answers.assert_content
-    cookies_page.store_answers.assert_table
-
-    expect(cookies_page.more_secure).to have_header
-    cookies_page.more_secure.assert_content
-  end
-
-  scenario "from employer contract claim page" do
-    employers_contract_claim_page.load(locale: current_locale_parameter)
-
-    employers_contract_claim_page.cookies.click
-
-    expect(cookies_page).to be_displayed
-    expect(cookies_page).to have_header
-
-    expect(cookies_page).to have_introduction
-    cookies_page.introduction.assert_content
-
-    expect(cookies_page).to have_cookies_used_subheader
-
-    expect(cookies_page.website_usage).to have_header
-    cookies_page.website_usage.assert_content
-    cookies_page.website_usage.assert_table
-
-    expect(cookies_page.introductory_message).to have_header
-    cookies_page.introductory_message.assert_content
-    cookies_page.introductory_message.assert_table
-
-    expect(cookies_page.store_answers).to have_header
-    cookies_page.store_answers.assert_content
-    cookies_page.store_answers.assert_table
-
-    expect(cookies_page.more_secure).to have_header
-    cookies_page.more_secure.assert_content
-  end
-
-  scenario "from additional information page" do
-    additional_information_page.load(locale: current_locale_parameter)
-
-    additional_information_page.cookies.click
-
-    expect(cookies_page).to be_displayed
-    expect(cookies_page).to have_header
-
-    expect(cookies_page).to have_introduction
-    cookies_page.introduction.assert_content
-
-    expect(cookies_page).to have_cookies_used_subheader
-
-    expect(cookies_page.website_usage).to have_header
-    cookies_page.website_usage.assert_content
-    cookies_page.website_usage.assert_table
-
-    expect(cookies_page.introductory_message).to have_header
-    cookies_page.introductory_message.assert_content
-    cookies_page.introductory_message.assert_table
-
-    expect(cookies_page.store_answers).to have_header
-    cookies_page.store_answers.assert_content
-    cookies_page.store_answers.assert_table
-
-    expect(cookies_page.more_secure).to have_header
-    cookies_page.more_secure.assert_content
-  end
-
-  scenario "from confirmation of supplied details page" do
-    confirmation_of_supplied_details_page.load(locale: current_locale_parameter)
-
-    confirmation_of_supplied_details_page.cookies.click
-
-    expect(cookies_page).to be_displayed
-    expect(cookies_page).to have_header
-
-    expect(cookies_page).to have_introduction
-    cookies_page.introduction.assert_content
-
-    expect(cookies_page).to have_cookies_used_subheader
-
-    expect(cookies_page.website_usage).to have_header
-    cookies_page.website_usage.assert_content
-    cookies_page.website_usage.assert_table
-
-    expect(cookies_page.introductory_message).to have_header
-    cookies_page.introductory_message.assert_content
-    cookies_page.introductory_message.assert_table
-
-    expect(cookies_page.store_answers).to have_header
-    cookies_page.store_answers.assert_content
-    cookies_page.store_answers.assert_table
-
-    expect(cookies_page.more_secure).to have_header
-    cookies_page.more_secure.assert_content
+      expect(cookies_page.more_secure).to have_header
+      cookies_page.more_secure.assert_content
+    end
   end
 
   scenario "from form submission page" do
@@ -364,6 +76,72 @@ RSpec.feature "Access Cookies", js: true do
 
     expect(cookies_page.more_secure).to have_header
     cookies_page.more_secure.assert_content
+  end
+
+  context "when originally on the start page" do
+    let(:current_page) { ET3::Test::StartPage.new }
+
+    include_examples "on a per-page basis"
+  end
+
+  context "when originally on the respondent's details page" do
+    let(:current_page) { ET3::Test::RespondentsDetailsPage.new }
+
+    include_examples "on a per-page basis"
+  end
+
+  context "when originally on the claimant's details page" do
+    let(:current_page) { ET3::Test::ClaimantsDetailsPage.new }
+
+    include_examples "on a per-page basis"
+  end
+
+  context "when originally on the earnings and benefits page" do
+    let(:current_page) { ET3::Test::EarningsAndBenefitsPage.new }
+
+    include_examples "on a per-page basis"
+  end
+
+  context "when originally on the response page" do
+    let(:current_page) { ET3::Test::ResponsePage.new }
+
+    include_examples "on a per-page basis"
+  end
+
+  context "when originally on the your representative page" do
+    let(:current_page) { ET3::Test::ResponsePage.new }
+
+    include_examples "on a per-page basis"
+  end
+
+  context "when originally on the your representative's details page" do
+    let(:current_page) { ET3::Test::ResponsePage.new }
+
+    include_examples "on a per-page basis"
+  end
+
+  context "when originally on the disability page" do
+    let(:current_page) { ET3::Test::DisabilityPage.new }
+
+    include_examples "on a per-page basis"
+  end
+
+  context "when originally on the employer contract claim page" do
+    let(:current_page) { ET3::Test::EmployersContractClaimPage.new }
+
+    include_examples "on a per-page basis"
+  end
+
+  context "when originally on the additional information page" do
+    let(:current_page) { ET3::Test::AdditionalInformationPage.new }
+
+    include_examples "on a per-page basis"
+  end
+
+  context "when originally on the confirmation of supplied details page" do
+    let(:current_page) { ET3::Test::ConfirmationOfSuppliedDetailsPage.new }
+
+    include_examples "on a per-page basis"
   end
 
 end

--- a/spec/features/access_cookies_spec.rb
+++ b/spec/features/access_cookies_spec.rb
@@ -17,6 +17,7 @@ RSpec.feature "Access Cookies", js: true do
     expect(cookies_page).to have_header
 
     expect(cookies_page).to have_introduction
+    cookies_page.introduction.assert_content
 
     expect(cookies_page).to have_cookies_used_subheader
 
@@ -45,6 +46,7 @@ RSpec.feature "Access Cookies", js: true do
     expect(cookies_page).to have_header
 
     expect(cookies_page).to have_introduction
+    cookies_page.introduction.assert_content
 
     expect(cookies_page).to have_cookies_used_subheader
 
@@ -62,7 +64,6 @@ RSpec.feature "Access Cookies", js: true do
 
     expect(cookies_page.more_secure).to have_header
     cookies_page.more_secure.assert_content
-
   end
 
   scenario "from claimant's details page" do
@@ -74,6 +75,7 @@ RSpec.feature "Access Cookies", js: true do
     expect(cookies_page).to have_header
 
     expect(cookies_page).to have_introduction
+    cookies_page.introduction.assert_content
 
     expect(cookies_page).to have_cookies_used_subheader
 
@@ -91,7 +93,6 @@ RSpec.feature "Access Cookies", js: true do
 
     expect(cookies_page.more_secure).to have_header
     cookies_page.more_secure.assert_content
-
   end
 
   scenario "from earnings and benefits page" do
@@ -103,6 +104,7 @@ RSpec.feature "Access Cookies", js: true do
     expect(cookies_page).to have_header
 
     expect(cookies_page).to have_introduction
+    cookies_page.introduction.assert_content
 
     expect(cookies_page).to have_cookies_used_subheader
 
@@ -120,7 +122,6 @@ RSpec.feature "Access Cookies", js: true do
 
     expect(cookies_page.more_secure).to have_header
     cookies_page.more_secure.assert_content
-
   end
 
   scenario "from response page" do
@@ -128,11 +129,11 @@ RSpec.feature "Access Cookies", js: true do
 
     response_page.cookies.click
 
-
     expect(cookies_page).to be_displayed
     expect(cookies_page).to have_header
 
     expect(cookies_page).to have_introduction
+    cookies_page.introduction.assert_content
 
     expect(cookies_page).to have_cookies_used_subheader
 
@@ -150,7 +151,6 @@ RSpec.feature "Access Cookies", js: true do
 
     expect(cookies_page.more_secure).to have_header
     cookies_page.more_secure.assert_content
-
   end
 
   scenario "from your representative page" do
@@ -158,11 +158,11 @@ RSpec.feature "Access Cookies", js: true do
 
     your_representative_page.cookies.click
 
-
     expect(cookies_page).to be_displayed
     expect(cookies_page).to have_header
 
     expect(cookies_page).to have_introduction
+    cookies_page.introduction.assert_content
 
     expect(cookies_page).to have_cookies_used_subheader
 
@@ -180,7 +180,6 @@ RSpec.feature "Access Cookies", js: true do
 
     expect(cookies_page.more_secure).to have_header
     cookies_page.more_secure.assert_content
-
   end
 
   scenario "from your representative's details page" do
@@ -188,11 +187,11 @@ RSpec.feature "Access Cookies", js: true do
 
     your_representatives_details_page.cookies.click
 
-
     expect(cookies_page).to be_displayed
     expect(cookies_page).to have_header
 
     expect(cookies_page).to have_introduction
+    cookies_page.introduction.assert_content
 
     expect(cookies_page).to have_cookies_used_subheader
 
@@ -210,7 +209,6 @@ RSpec.feature "Access Cookies", js: true do
 
     expect(cookies_page.more_secure).to have_header
     cookies_page.more_secure.assert_content
-
   end
 
   scenario "from disability page" do
@@ -218,11 +216,11 @@ RSpec.feature "Access Cookies", js: true do
 
     disability_page.cookies.click
 
-
     expect(cookies_page).to be_displayed
     expect(cookies_page).to have_header
 
     expect(cookies_page).to have_introduction
+    cookies_page.introduction.assert_content
 
     expect(cookies_page).to have_cookies_used_subheader
 
@@ -240,7 +238,6 @@ RSpec.feature "Access Cookies", js: true do
 
     expect(cookies_page.more_secure).to have_header
     cookies_page.more_secure.assert_content
-
   end
 
   scenario "from employer contract claim page" do
@@ -248,11 +245,11 @@ RSpec.feature "Access Cookies", js: true do
 
     employers_contract_claim_page.cookies.click
 
-
     expect(cookies_page).to be_displayed
     expect(cookies_page).to have_header
 
     expect(cookies_page).to have_introduction
+    cookies_page.introduction.assert_content
 
     expect(cookies_page).to have_cookies_used_subheader
 
@@ -270,7 +267,6 @@ RSpec.feature "Access Cookies", js: true do
 
     expect(cookies_page.more_secure).to have_header
     cookies_page.more_secure.assert_content
-
   end
 
   scenario "from additional information page" do
@@ -278,11 +274,11 @@ RSpec.feature "Access Cookies", js: true do
 
     additional_information_page.cookies.click
 
-
     expect(cookies_page).to be_displayed
     expect(cookies_page).to have_header
 
     expect(cookies_page).to have_introduction
+    cookies_page.introduction.assert_content
 
     expect(cookies_page).to have_cookies_used_subheader
 
@@ -300,7 +296,6 @@ RSpec.feature "Access Cookies", js: true do
 
     expect(cookies_page.more_secure).to have_header
     cookies_page.more_secure.assert_content
-
   end
 
   scenario "from confirmation of supplied details page" do
@@ -308,11 +303,11 @@ RSpec.feature "Access Cookies", js: true do
 
     confirmation_of_supplied_details_page.cookies.click
 
-
     expect(cookies_page).to be_displayed
     expect(cookies_page).to have_header
 
     expect(cookies_page).to have_introduction
+    cookies_page.introduction.assert_content
 
     expect(cookies_page).to have_cookies_used_subheader
 
@@ -330,7 +325,6 @@ RSpec.feature "Access Cookies", js: true do
 
     expect(cookies_page.more_secure).to have_header
     cookies_page.more_secure.assert_content
-
   end
 
   scenario "from form submission page" do
@@ -348,11 +342,11 @@ RSpec.feature "Access Cookies", js: true do
 
     form_submission_page.cookies.click
 
-
     expect(cookies_page).to be_displayed
     expect(cookies_page).to have_header
 
     expect(cookies_page).to have_introduction
+    cookies_page.introduction.assert_content
 
     expect(cookies_page).to have_cookies_used_subheader
 
@@ -370,7 +364,6 @@ RSpec.feature "Access Cookies", js: true do
 
     expect(cookies_page.more_secure).to have_header
     cookies_page.more_secure.assert_content
-
   end
 
 end

--- a/spec/features/access_cookies_spec.rb
+++ b/spec/features/access_cookies_spec.rb
@@ -1,0 +1,376 @@
+require 'rails_helper'
+
+RSpec.feature "Access Cookies", js: true do
+  include ET3::Test::I18n
+
+  before do
+    stub_et_api
+    stub_build_blob_to_azure
+  end
+
+  scenario "from start page" do
+    start_page.load(locale: current_locale_parameter)
+
+    start_page.cookies.click
+
+    expect(cookies_page).to be_displayed
+    expect(cookies_page).to have_header
+
+    expect(cookies_page).to have_introduction
+
+    expect(cookies_page).to have_cookies_used_subheader
+
+    expect(cookies_page.website_usage).to have_header
+    cookies_page.website_usage.assert_content
+    cookies_page.website_usage.assert_table
+
+    expect(cookies_page.introductory_message).to have_header
+    cookies_page.introductory_message.assert_content
+    cookies_page.introductory_message.assert_table
+
+    expect(cookies_page.store_answers).to have_header
+    cookies_page.store_answers.assert_content
+    cookies_page.store_answers.assert_table
+
+    expect(cookies_page.more_secure).to have_header
+    cookies_page.more_secure.assert_content
+  end
+
+  scenario "from respondent's details page" do
+    respondents_details_page.load(locale: current_locale_parameter)
+
+    respondents_details_page.cookies.click
+
+    expect(cookies_page).to be_displayed
+    expect(cookies_page).to have_header
+
+    expect(cookies_page).to have_introduction
+
+    expect(cookies_page).to have_cookies_used_subheader
+
+    expect(cookies_page.website_usage).to have_header
+    cookies_page.website_usage.assert_content
+    cookies_page.website_usage.assert_table
+
+    expect(cookies_page.introductory_message).to have_header
+    cookies_page.introductory_message.assert_content
+    cookies_page.introductory_message.assert_table
+
+    expect(cookies_page.store_answers).to have_header
+    cookies_page.store_answers.assert_content
+    cookies_page.store_answers.assert_table
+
+    expect(cookies_page.more_secure).to have_header
+    cookies_page.more_secure.assert_content
+
+  end
+
+  scenario "from claimant's details page" do
+    claimants_details_page.load(locale: current_locale_parameter)
+
+    claimants_details_page.cookies.click
+
+    expect(cookies_page).to be_displayed
+    expect(cookies_page).to have_header
+
+    expect(cookies_page).to have_introduction
+
+    expect(cookies_page).to have_cookies_used_subheader
+
+    expect(cookies_page.website_usage).to have_header
+    cookies_page.website_usage.assert_content
+    cookies_page.website_usage.assert_table
+
+    expect(cookies_page.introductory_message).to have_header
+    cookies_page.introductory_message.assert_content
+    cookies_page.introductory_message.assert_table
+
+    expect(cookies_page.store_answers).to have_header
+    cookies_page.store_answers.assert_content
+    cookies_page.store_answers.assert_table
+
+    expect(cookies_page.more_secure).to have_header
+    cookies_page.more_secure.assert_content
+
+  end
+
+  scenario "from earnings and benefits page" do
+    earnings_and_benefits_page.load(locale: current_locale_parameter)
+
+    earnings_and_benefits_page.cookies.click
+
+    expect(cookies_page).to be_displayed
+    expect(cookies_page).to have_header
+
+    expect(cookies_page).to have_introduction
+
+    expect(cookies_page).to have_cookies_used_subheader
+
+    expect(cookies_page.website_usage).to have_header
+    cookies_page.website_usage.assert_content
+    cookies_page.website_usage.assert_table
+
+    expect(cookies_page.introductory_message).to have_header
+    cookies_page.introductory_message.assert_content
+    cookies_page.introductory_message.assert_table
+
+    expect(cookies_page.store_answers).to have_header
+    cookies_page.store_answers.assert_content
+    cookies_page.store_answers.assert_table
+
+    expect(cookies_page.more_secure).to have_header
+    cookies_page.more_secure.assert_content
+
+  end
+
+  scenario "from response page" do
+    response_page.load(locale: current_locale_parameter)
+
+    response_page.cookies.click
+
+
+    expect(cookies_page).to be_displayed
+    expect(cookies_page).to have_header
+
+    expect(cookies_page).to have_introduction
+
+    expect(cookies_page).to have_cookies_used_subheader
+
+    expect(cookies_page.website_usage).to have_header
+    cookies_page.website_usage.assert_content
+    cookies_page.website_usage.assert_table
+
+    expect(cookies_page.introductory_message).to have_header
+    cookies_page.introductory_message.assert_content
+    cookies_page.introductory_message.assert_table
+
+    expect(cookies_page.store_answers).to have_header
+    cookies_page.store_answers.assert_content
+    cookies_page.store_answers.assert_table
+
+    expect(cookies_page.more_secure).to have_header
+    cookies_page.more_secure.assert_content
+
+  end
+
+  scenario "from your representative page" do
+    your_representative_page.load(locale: current_locale_parameter)
+
+    your_representative_page.cookies.click
+
+
+    expect(cookies_page).to be_displayed
+    expect(cookies_page).to have_header
+
+    expect(cookies_page).to have_introduction
+
+    expect(cookies_page).to have_cookies_used_subheader
+
+    expect(cookies_page.website_usage).to have_header
+    cookies_page.website_usage.assert_content
+    cookies_page.website_usage.assert_table
+
+    expect(cookies_page.introductory_message).to have_header
+    cookies_page.introductory_message.assert_content
+    cookies_page.introductory_message.assert_table
+
+    expect(cookies_page.store_answers).to have_header
+    cookies_page.store_answers.assert_content
+    cookies_page.store_answers.assert_table
+
+    expect(cookies_page.more_secure).to have_header
+    cookies_page.more_secure.assert_content
+
+  end
+
+  scenario "from your representative's details page" do
+    your_representatives_details_page.load(locale: current_locale_parameter)
+
+    your_representatives_details_page.cookies.click
+
+
+    expect(cookies_page).to be_displayed
+    expect(cookies_page).to have_header
+
+    expect(cookies_page).to have_introduction
+
+    expect(cookies_page).to have_cookies_used_subheader
+
+    expect(cookies_page.website_usage).to have_header
+    cookies_page.website_usage.assert_content
+    cookies_page.website_usage.assert_table
+
+    expect(cookies_page.introductory_message).to have_header
+    cookies_page.introductory_message.assert_content
+    cookies_page.introductory_message.assert_table
+
+    expect(cookies_page.store_answers).to have_header
+    cookies_page.store_answers.assert_content
+    cookies_page.store_answers.assert_table
+
+    expect(cookies_page.more_secure).to have_header
+    cookies_page.more_secure.assert_content
+
+  end
+
+  scenario "from disability page" do
+    disability_page.load(locale: current_locale_parameter)
+
+    disability_page.cookies.click
+
+
+    expect(cookies_page).to be_displayed
+    expect(cookies_page).to have_header
+
+    expect(cookies_page).to have_introduction
+
+    expect(cookies_page).to have_cookies_used_subheader
+
+    expect(cookies_page.website_usage).to have_header
+    cookies_page.website_usage.assert_content
+    cookies_page.website_usage.assert_table
+
+    expect(cookies_page.introductory_message).to have_header
+    cookies_page.introductory_message.assert_content
+    cookies_page.introductory_message.assert_table
+
+    expect(cookies_page.store_answers).to have_header
+    cookies_page.store_answers.assert_content
+    cookies_page.store_answers.assert_table
+
+    expect(cookies_page.more_secure).to have_header
+    cookies_page.more_secure.assert_content
+
+  end
+
+  scenario "from employer contract claim page" do
+    employers_contract_claim_page.load(locale: current_locale_parameter)
+
+    employers_contract_claim_page.cookies.click
+
+
+    expect(cookies_page).to be_displayed
+    expect(cookies_page).to have_header
+
+    expect(cookies_page).to have_introduction
+
+    expect(cookies_page).to have_cookies_used_subheader
+
+    expect(cookies_page.website_usage).to have_header
+    cookies_page.website_usage.assert_content
+    cookies_page.website_usage.assert_table
+
+    expect(cookies_page.introductory_message).to have_header
+    cookies_page.introductory_message.assert_content
+    cookies_page.introductory_message.assert_table
+
+    expect(cookies_page.store_answers).to have_header
+    cookies_page.store_answers.assert_content
+    cookies_page.store_answers.assert_table
+
+    expect(cookies_page.more_secure).to have_header
+    cookies_page.more_secure.assert_content
+
+  end
+
+  scenario "from additional information page" do
+    additional_information_page.load(locale: current_locale_parameter)
+
+    additional_information_page.cookies.click
+
+
+    expect(cookies_page).to be_displayed
+    expect(cookies_page).to have_header
+
+    expect(cookies_page).to have_introduction
+
+    expect(cookies_page).to have_cookies_used_subheader
+
+    expect(cookies_page.website_usage).to have_header
+    cookies_page.website_usage.assert_content
+    cookies_page.website_usage.assert_table
+
+    expect(cookies_page.introductory_message).to have_header
+    cookies_page.introductory_message.assert_content
+    cookies_page.introductory_message.assert_table
+
+    expect(cookies_page.store_answers).to have_header
+    cookies_page.store_answers.assert_content
+    cookies_page.store_answers.assert_table
+
+    expect(cookies_page.more_secure).to have_header
+    cookies_page.more_secure.assert_content
+
+  end
+
+  scenario "from confirmation of supplied details page" do
+    confirmation_of_supplied_details_page.load(locale: current_locale_parameter)
+
+    confirmation_of_supplied_details_page.cookies.click
+
+
+    expect(cookies_page).to be_displayed
+    expect(cookies_page).to have_header
+
+    expect(cookies_page).to have_introduction
+
+    expect(cookies_page).to have_cookies_used_subheader
+
+    expect(cookies_page.website_usage).to have_header
+    cookies_page.website_usage.assert_content
+    cookies_page.website_usage.assert_table
+
+    expect(cookies_page.introductory_message).to have_header
+    cookies_page.introductory_message.assert_content
+    cookies_page.introductory_message.assert_table
+
+    expect(cookies_page.store_answers).to have_header
+    cookies_page.store_answers.assert_content
+    cookies_page.store_answers.assert_table
+
+    expect(cookies_page.more_secure).to have_header
+    cookies_page.more_secure.assert_content
+
+  end
+
+  scenario "from form submission page" do
+    given_valid_data
+    start_a_new_et3_response
+    answer_respondents_details
+    answer_claimants_details
+    answer_earnings_and_benefits
+    answer_defend_claim_question
+    answer_representative
+    answer_disability_question
+    answer_employers_contract_claim
+    answer_additional_information
+    answer_confirmation_of_supplied_details
+
+    form_submission_page.cookies.click
+
+
+    expect(cookies_page).to be_displayed
+    expect(cookies_page).to have_header
+
+    expect(cookies_page).to have_introduction
+
+    expect(cookies_page).to have_cookies_used_subheader
+
+    expect(cookies_page.website_usage).to have_header
+    cookies_page.website_usage.assert_content
+    cookies_page.website_usage.assert_table
+
+    expect(cookies_page.introductory_message).to have_header
+    cookies_page.introductory_message.assert_content
+    cookies_page.introductory_message.assert_table
+
+    expect(cookies_page.store_answers).to have_header
+    cookies_page.store_answers.assert_content
+    cookies_page.store_answers.assert_table
+
+    expect(cookies_page.more_secure).to have_header
+    cookies_page.more_secure.assert_content
+
+  end
+
+end

--- a/spec/features/view_footer_spec.rb
+++ b/spec/features/view_footer_spec.rb
@@ -11,78 +11,89 @@ RSpec.feature "View Footer", js: true do
   scenario "on start page" do
     start_page.load(locale: current_locale_parameter)
 
-    expect(start_page).to have_link(t('components.footer.terms'), href: terms_and_conditions_path(locale: current_locale_parameter))
+    expect(start_page).to have_link(t('components.footer.cookies'), href: cookies_path(locale: current_locale_parameter))
     expect(start_page).to have_link(t('components.footer.privacy'), href: privacy_notice_path(locale: current_locale_parameter))
+    expect(start_page).to have_link(t('components.footer.terms'), href: terms_and_conditions_path(locale: current_locale_parameter))
   end
 
   scenario "on respondent's details page" do
     respondents_details_page.load(locale: current_locale_parameter)
 
-    expect(respondents_details_page).to have_link(t('components.footer.terms'), href: terms_and_conditions_path(locale: current_locale_parameter))
-    expect(respondents_details_page).to have_link(t('components.footer.privacy'), href: privacy_notice_path(locale: current_locale_parameter))
+    expect(start_page).to have_link(t('components.footer.cookies'), href: cookies_path(locale: current_locale_parameter))
+    expect(start_page).to have_link(t('components.footer.privacy'), href: privacy_notice_path(locale: current_locale_parameter))
+    expect(start_page).to have_link(t('components.footer.terms'), href: terms_and_conditions_path(locale: current_locale_parameter))
   end
 
   scenario "on claimant's details page" do
     claimants_details_page.load(locale: current_locale_parameter)
 
-    expect(claimants_details_page).to have_link(t('components.footer.terms'), href: terms_and_conditions_path(locale: current_locale_parameter))
-    expect(claimants_details_page).to have_link(t('components.footer.privacy'), href: privacy_notice_path(locale: current_locale_parameter))
+    expect(start_page).to have_link(t('components.footer.cookies'), href: cookies_path(locale: current_locale_parameter))
+    expect(start_page).to have_link(t('components.footer.privacy'), href: privacy_notice_path(locale: current_locale_parameter))
+    expect(start_page).to have_link(t('components.footer.terms'), href: terms_and_conditions_path(locale: current_locale_parameter))
   end
 
   scenario "on earnings and benefits page" do
     earnings_and_benefits_page.load(locale: current_locale_parameter)
 
-    expect(earnings_and_benefits_page).to have_link(t('components.footer.terms'), href: terms_and_conditions_path(locale: current_locale_parameter))
-    expect(earnings_and_benefits_page).to have_link(t('components.footer.privacy'), href: privacy_notice_path(locale: current_locale_parameter))
+    expect(start_page).to have_link(t('components.footer.cookies'), href: cookies_path(locale: current_locale_parameter))
+    expect(start_page).to have_link(t('components.footer.privacy'), href: privacy_notice_path(locale: current_locale_parameter))
+    expect(start_page).to have_link(t('components.footer.terms'), href: terms_and_conditions_path(locale: current_locale_parameter))
   end
 
   scenario "on response page" do
     response_page.load(locale: current_locale_parameter)
 
-    expect(response_page).to have_link(t('components.footer.terms'), href: terms_and_conditions_path(locale: current_locale_parameter))
-    expect(response_page).to have_link(t('components.footer.privacy'), href: privacy_notice_path(locale: current_locale_parameter))
+    expect(start_page).to have_link(t('components.footer.cookies'), href: cookies_path(locale: current_locale_parameter))
+    expect(start_page).to have_link(t('components.footer.privacy'), href: privacy_notice_path(locale: current_locale_parameter))
+    expect(start_page).to have_link(t('components.footer.terms'), href: terms_and_conditions_path(locale: current_locale_parameter))
   end
 
   scenario "on your representative page" do
     your_representative_page.load(locale: current_locale_parameter)
 
-    expect(your_representative_page).to have_link(t('components.footer.terms'), href: terms_and_conditions_path(locale: current_locale_parameter))
-    expect(your_representative_page).to have_link(t('components.footer.privacy'), href: privacy_notice_path(locale: current_locale_parameter))
+    expect(start_page).to have_link(t('components.footer.cookies'), href: cookies_path(locale: current_locale_parameter))
+    expect(start_page).to have_link(t('components.footer.privacy'), href: privacy_notice_path(locale: current_locale_parameter))
+    expect(start_page).to have_link(t('components.footer.terms'), href: terms_and_conditions_path(locale: current_locale_parameter))
   end
 
   scenario "on your representative's details page" do
     your_representatives_details_page.load(locale: current_locale_parameter)
 
-    expect(your_representatives_details_page).to have_link(t('components.footer.terms'), href: terms_and_conditions_path(locale: current_locale_parameter))
-    expect(your_representatives_details_page).to have_link(t('components.footer.privacy'), href: privacy_notice_path(locale: current_locale_parameter))
+    expect(start_page).to have_link(t('components.footer.cookies'), href: cookies_path(locale: current_locale_parameter))
+    expect(start_page).to have_link(t('components.footer.privacy'), href: privacy_notice_path(locale: current_locale_parameter))
+    expect(start_page).to have_link(t('components.footer.terms'), href: terms_and_conditions_path(locale: current_locale_parameter))
   end
 
   scenario "on disability page" do
     disability_page.load(locale: current_locale_parameter)
 
-    expect(disability_page).to have_link(t('components.footer.terms'), href: terms_and_conditions_path(locale: current_locale_parameter))
-    expect(disability_page).to have_link(t('components.footer.privacy'), href: privacy_notice_path(locale: current_locale_parameter))
+    expect(start_page).to have_link(t('components.footer.cookies'), href: cookies_path(locale: current_locale_parameter))
+    expect(start_page).to have_link(t('components.footer.privacy'), href: privacy_notice_path(locale: current_locale_parameter))
+    expect(start_page).to have_link(t('components.footer.terms'), href: terms_and_conditions_path(locale: current_locale_parameter))
   end
 
   scenario "on employer contract claim page" do
     employers_contract_claim_page.load(locale: current_locale_parameter)
 
-    expect(employers_contract_claim_page).to have_link(t('components.footer.terms'), href: terms_and_conditions_path(locale: current_locale_parameter))
-    expect(employers_contract_claim_page).to have_link(t('components.footer.privacy'), href: privacy_notice_path(locale: current_locale_parameter))
+    expect(start_page).to have_link(t('components.footer.cookies'), href: cookies_path(locale: current_locale_parameter))
+    expect(start_page).to have_link(t('components.footer.privacy'), href: privacy_notice_path(locale: current_locale_parameter))
+    expect(start_page).to have_link(t('components.footer.terms'), href: terms_and_conditions_path(locale: current_locale_parameter))
   end
 
   scenario "on additional information page" do
     additional_information_page.load(locale: current_locale_parameter)
 
-    expect(additional_information_page).to have_link(t('components.footer.terms'), href: terms_and_conditions_path(locale: current_locale_parameter))
-    expect(additional_information_page).to have_link(t('components.footer.privacy'), href: privacy_notice_path(locale: current_locale_parameter))
+    expect(start_page).to have_link(t('components.footer.cookies'), href: cookies_path(locale: current_locale_parameter))
+    expect(start_page).to have_link(t('components.footer.privacy'), href: privacy_notice_path(locale: current_locale_parameter))
+    expect(start_page).to have_link(t('components.footer.terms'), href: terms_and_conditions_path(locale: current_locale_parameter))
   end
 
   scenario "on confirmation of supplied details page" do
     confirmation_of_supplied_details_page.load(locale: current_locale_parameter)
 
-    expect(confirmation_of_supplied_details_page).to have_link(t('components.footer.terms'), href: terms_and_conditions_path(locale: current_locale_parameter))
-    expect(confirmation_of_supplied_details_page).to have_link(t('components.footer.privacy'), href: privacy_notice_path(locale: current_locale_parameter))
+    expect(start_page).to have_link(t('components.footer.cookies'), href: cookies_path(locale: current_locale_parameter))
+    expect(start_page).to have_link(t('components.footer.privacy'), href: privacy_notice_path(locale: current_locale_parameter))
+    expect(start_page).to have_link(t('components.footer.terms'), href: terms_and_conditions_path(locale: current_locale_parameter))
   end
 
   scenario "on form submission page" do
@@ -98,8 +109,9 @@ RSpec.feature "View Footer", js: true do
     answer_additional_information
     answer_confirmation_of_supplied_details
 
-    expect(form_submission_page).to have_link(t('components.footer.terms'), href: terms_and_conditions_path(locale: current_locale_parameter))
-    expect(form_submission_page).to have_link(t('components.footer.privacy'), href: privacy_notice_path(locale: current_locale_parameter))
+    expect(start_page).to have_link(t('components.footer.cookies'), href: cookies_path(locale: current_locale_parameter))
+    expect(start_page).to have_link(t('components.footer.privacy'), href: privacy_notice_path(locale: current_locale_parameter))
+    expect(start_page).to have_link(t('components.footer.terms'), href: terms_and_conditions_path(locale: current_locale_parameter))
   end
 
 end

--- a/spec/features/view_footer_spec.rb
+++ b/spec/features/view_footer_spec.rb
@@ -8,92 +8,14 @@ RSpec.feature "View Footer", js: true do
     stub_build_blob_to_azure
   end
 
-  scenario "on start page" do
-    start_page.load(locale: current_locale_parameter)
+  shared_examples "on a per-page basis" do
+    scenario "will show footer links" do
+      current_page.load(locale: current_locale_parameter)
 
-    expect(start_page).to have_link(t('components.footer.cookies'), href: cookies_path(locale: current_locale_parameter))
-    expect(start_page).to have_link(t('components.footer.privacy'), href: privacy_notice_path(locale: current_locale_parameter))
-    expect(start_page).to have_link(t('components.footer.terms'), href: terms_and_conditions_path(locale: current_locale_parameter))
-  end
-
-  scenario "on respondent's details page" do
-    respondents_details_page.load(locale: current_locale_parameter)
-
-    expect(start_page).to have_link(t('components.footer.cookies'), href: cookies_path(locale: current_locale_parameter))
-    expect(start_page).to have_link(t('components.footer.privacy'), href: privacy_notice_path(locale: current_locale_parameter))
-    expect(start_page).to have_link(t('components.footer.terms'), href: terms_and_conditions_path(locale: current_locale_parameter))
-  end
-
-  scenario "on claimant's details page" do
-    claimants_details_page.load(locale: current_locale_parameter)
-
-    expect(start_page).to have_link(t('components.footer.cookies'), href: cookies_path(locale: current_locale_parameter))
-    expect(start_page).to have_link(t('components.footer.privacy'), href: privacy_notice_path(locale: current_locale_parameter))
-    expect(start_page).to have_link(t('components.footer.terms'), href: terms_and_conditions_path(locale: current_locale_parameter))
-  end
-
-  scenario "on earnings and benefits page" do
-    earnings_and_benefits_page.load(locale: current_locale_parameter)
-
-    expect(start_page).to have_link(t('components.footer.cookies'), href: cookies_path(locale: current_locale_parameter))
-    expect(start_page).to have_link(t('components.footer.privacy'), href: privacy_notice_path(locale: current_locale_parameter))
-    expect(start_page).to have_link(t('components.footer.terms'), href: terms_and_conditions_path(locale: current_locale_parameter))
-  end
-
-  scenario "on response page" do
-    response_page.load(locale: current_locale_parameter)
-
-    expect(start_page).to have_link(t('components.footer.cookies'), href: cookies_path(locale: current_locale_parameter))
-    expect(start_page).to have_link(t('components.footer.privacy'), href: privacy_notice_path(locale: current_locale_parameter))
-    expect(start_page).to have_link(t('components.footer.terms'), href: terms_and_conditions_path(locale: current_locale_parameter))
-  end
-
-  scenario "on your representative page" do
-    your_representative_page.load(locale: current_locale_parameter)
-
-    expect(start_page).to have_link(t('components.footer.cookies'), href: cookies_path(locale: current_locale_parameter))
-    expect(start_page).to have_link(t('components.footer.privacy'), href: privacy_notice_path(locale: current_locale_parameter))
-    expect(start_page).to have_link(t('components.footer.terms'), href: terms_and_conditions_path(locale: current_locale_parameter))
-  end
-
-  scenario "on your representative's details page" do
-    your_representatives_details_page.load(locale: current_locale_parameter)
-
-    expect(start_page).to have_link(t('components.footer.cookies'), href: cookies_path(locale: current_locale_parameter))
-    expect(start_page).to have_link(t('components.footer.privacy'), href: privacy_notice_path(locale: current_locale_parameter))
-    expect(start_page).to have_link(t('components.footer.terms'), href: terms_and_conditions_path(locale: current_locale_parameter))
-  end
-
-  scenario "on disability page" do
-    disability_page.load(locale: current_locale_parameter)
-
-    expect(start_page).to have_link(t('components.footer.cookies'), href: cookies_path(locale: current_locale_parameter))
-    expect(start_page).to have_link(t('components.footer.privacy'), href: privacy_notice_path(locale: current_locale_parameter))
-    expect(start_page).to have_link(t('components.footer.terms'), href: terms_and_conditions_path(locale: current_locale_parameter))
-  end
-
-  scenario "on employer contract claim page" do
-    employers_contract_claim_page.load(locale: current_locale_parameter)
-
-    expect(start_page).to have_link(t('components.footer.cookies'), href: cookies_path(locale: current_locale_parameter))
-    expect(start_page).to have_link(t('components.footer.privacy'), href: privacy_notice_path(locale: current_locale_parameter))
-    expect(start_page).to have_link(t('components.footer.terms'), href: terms_and_conditions_path(locale: current_locale_parameter))
-  end
-
-  scenario "on additional information page" do
-    additional_information_page.load(locale: current_locale_parameter)
-
-    expect(start_page).to have_link(t('components.footer.cookies'), href: cookies_path(locale: current_locale_parameter))
-    expect(start_page).to have_link(t('components.footer.privacy'), href: privacy_notice_path(locale: current_locale_parameter))
-    expect(start_page).to have_link(t('components.footer.terms'), href: terms_and_conditions_path(locale: current_locale_parameter))
-  end
-
-  scenario "on confirmation of supplied details page" do
-    confirmation_of_supplied_details_page.load(locale: current_locale_parameter)
-
-    expect(start_page).to have_link(t('components.footer.cookies'), href: cookies_path(locale: current_locale_parameter))
-    expect(start_page).to have_link(t('components.footer.privacy'), href: privacy_notice_path(locale: current_locale_parameter))
-    expect(start_page).to have_link(t('components.footer.terms'), href: terms_and_conditions_path(locale: current_locale_parameter))
+      expect(current_page).to have_link(t('components.footer.cookies'), href: cookies_path(locale: current_locale_parameter))
+      expect(current_page).to have_link(t('components.footer.privacy'), href: privacy_notice_path(locale: current_locale_parameter))
+      expect(current_page).to have_link(t('components.footer.terms'), href: terms_and_conditions_path(locale: current_locale_parameter))
+    end
   end
 
   scenario "on form submission page" do
@@ -109,9 +31,76 @@ RSpec.feature "View Footer", js: true do
     answer_additional_information
     answer_confirmation_of_supplied_details
 
-    expect(start_page).to have_link(t('components.footer.cookies'), href: cookies_path(locale: current_locale_parameter))
-    expect(start_page).to have_link(t('components.footer.privacy'), href: privacy_notice_path(locale: current_locale_parameter))
-    expect(start_page).to have_link(t('components.footer.terms'), href: terms_and_conditions_path(locale: current_locale_parameter))
+    expect(form_submission_page).to have_link(t('components.footer.cookies'), href: cookies_path(locale: current_locale_parameter))
+    expect(form_submission_page).to have_link(t('components.footer.privacy'), href: privacy_notice_path(locale: current_locale_parameter))
+    expect(form_submission_page).to have_link(t('components.footer.terms'), href: terms_and_conditions_path(locale: current_locale_parameter))
+  end
+
+
+  context "when originally on the start page" do
+    let(:current_page) { ET3::Test::StartPage.new }
+
+    include_examples "on a per-page basis"
+  end
+
+  context "when originally on the respondent's details page" do
+    let(:current_page) { ET3::Test::RespondentsDetailsPage.new }
+
+    include_examples "on a per-page basis"
+  end
+
+  context "when originally on the claimant's details page" do
+    let(:current_page) { ET3::Test::ClaimantsDetailsPage.new }
+
+    include_examples "on a per-page basis"
+  end
+
+  context "when originally on the earnings and benefits page" do
+    let(:current_page) { ET3::Test::EarningsAndBenefitsPage.new }
+
+    include_examples "on a per-page basis"
+  end
+
+  context "when originally on the response page" do
+    let(:current_page) { ET3::Test::ResponsePage.new }
+
+    include_examples "on a per-page basis"
+  end
+
+  context "when originally on the your representative page" do
+    let(:current_page) { ET3::Test::ResponsePage.new }
+
+    include_examples "on a per-page basis"
+  end
+
+  context "when originally on the your representative's details page" do
+    let(:current_page) { ET3::Test::ResponsePage.new }
+
+    include_examples "on a per-page basis"
+  end
+
+  context "when originally on the disability page" do
+    let(:current_page) { ET3::Test::DisabilityPage.new }
+
+    include_examples "on a per-page basis"
+  end
+
+  context "when originally on the employer contract claim page" do
+    let(:current_page) { ET3::Test::EmployersContractClaimPage.new }
+
+    include_examples "on a per-page basis"
+  end
+
+  context "when originally on the additional information page" do
+    let(:current_page) { ET3::Test::AdditionalInformationPage.new }
+
+    include_examples "on a per-page basis"
+  end
+
+  context "when originally on the confirmation of supplied details page" do
+    let(:current_page) { ET3::Test::ConfirmationOfSuppliedDetailsPage.new }
+
+    include_examples "on a per-page basis"
   end
 
 end

--- a/test_common/helpers/pages.rb
+++ b/test_common/helpers/pages.rb
@@ -53,12 +53,16 @@ module ET3
         ET3::Test::FormSubmissionPage.new
       end
 
-      def terms_and_conditions_page
-        ET3::Test::TermsAndConditionsPage.new
+      def cookies_page
+        ET3::Test::CookiesPage.new
       end
 
       def privacy_notice_page
         ET3::Test::PrivacyNoticePage.new
+      end
+
+      def terms_and_conditions_page
+        ET3::Test::TermsAndConditionsPage.new
       end
 
       # Define other pages here

--- a/test_common/messaging/cy.yml
+++ b/test_common/messaging/cy.yml
@@ -310,6 +310,9 @@ cy:
       contact_us_href: Cysylltwch â ni
       privacy_policy_href: polisi preifatrwydd
       cookie_policy_href: polisi cwcis
+      managing_cookies_href: su i reoli cwcis
+      google_privacy_policy_href: Polisi Preifatrwydd
+      opt_out_href: optio allan o Google Analytics
   components:
     save_and_continue_button: "Cadw a pharhau"
     single_choice_option_section:
@@ -330,6 +333,7 @@ cy:
     footer:
       terms: Telerau ac amodau
       privacy: Polisi preifatrwydd
+      cookies: Cwcis
     confirmation_of_supplied_details:
       remove_file_link: "Dileu ffeil"
   introduction:
@@ -349,6 +353,59 @@ cy:
     data_title: Deddf Diogelu Data 1998
     data_content: "Byddwn yn anfon copi o'r ffurflen hon at yr hawlydd a'r Gwasanaeth Cynghori, Cymodi a Chyflafareddu (ACAS). Byddwn yn rhoi'r wybodaeth yr ydych yn ei rhoi inni ar y ffurflen hon ar gyfrifiadur. Mae hyn yn ein helpu i fonitro cynnydd a chynhyrchu ystadegau. Trosglwyddir yr wybodaeth a ddarperir ar y ffurflen hon i'r Adran Busnes, Arloesedd a Sgiliau i gynorthwyo ymchwil i'r defnydd a wneir o dribiwnlysoedd cyflogaeth ac effeithiolrwydd y tribiwnlysoedd hynny."
     start_now: Dechrau nawr
+  cookies:
+    header: Cwcis
+    introduction: "Darn bach o ddata sy'n cael ei storio ar eich cyfrifiadur, eich tabled neu eich ffôn pan fyddwch yn ymweld â gwefan yw Cwci. Mae angen cwcis ar y rhan fwyaf o wefannau i weithio'n iawn."
+    introduction_bullets:
+      - "Mae’r gwasanaeth hwn yn eu defnyddio i:"
+      - - fesur sut rydych yn defnyddio’r gwasanaeth hwn fel y gallwn ei wella
+        - cofio'r hysbysiadau rydych wedi'u gweld fel na fyddwch yn eu gweld eto
+        - storio’r atebion a roddwch dros dro
+      - Am ragor o wybodaeth, gweler %{managing_cookies_href}
+    subheader: Sut mae cwcis yn cael eu defnyddio yn y gwasanaeth hwn
+    website_usage:
+      header: 1. I fesur faint o bobl sy’n defnyddio ein gwefan
+      content:
+        - Rydym yn defnyddio meddalwedd Google Analytics i gasglu gwybodaeth am sut rydych yn defnyddio'r gwasanaeth hwn. Gwnawn hyn i helpu i sicrhau bod y gwasanaeth yn diwallu anghenion ei ddefnyddwyr ac i'n helpu i wneud gwelliannau, er enghraifft gwella’r cyfleuster chwilio.
+        - "Mae Google Analytics yn storio gwybodaeth am:"
+        - - y tudalennau yr ydych yn ymweld â hwy
+          - faint o amser y byddwch yn ei dreulio ar bob tudalen
+          - sut y daethoch o hyd i’r gwasanaeth
+          - yr hyn rydych chi'n clicio arno wrth ymweld â'r gwasanaeth
+        - Rydym yn caniatáu i Google ddefnyddio neu rannu ein data dadansoddi. Gallwch ddarganfod mwy am sut mae Google yn defnyddio’r wybodaeth hon yn eu %{google_privacy_policy_href}.
+        - Gallwch %{opt_out_href} os nad ydych am i Google gael mynediad at eich gwybodaeth.
+        - "Mae Google Analytics yn gosod y cwcis canlynol:"
+      table:
+        - - "_ga"
+          - Mae hyn yn ein helpu i gyfrif faint o bobl sy'n ymweld â'r gwasanaeth drwy olrhain os ydych wedi ymweld o'r blaen
+          - 2 flynedd
+        - - "_gat"
+          - Rheoli faint o bobl sy’n ymweld â’r dudalen
+          - 10 munud
+        - - "_gid"
+          - Eich cyfeirio at y gwasanaeth
+          - 24 awr
+    introductory_message:
+      header: 2. Troi ein neges gyflwyno i ffwrdd
+      content: Efallai y byddwch yn gweld neges groeso pan fyddwch yn ymweld â'r gwasanaeth am y tro cyntaf. Byddwn yn storio cwcis fel bod eich cyfrifiadur yn gwybod eich bod wedi ei gweld ac yn gwybod i beidio â'i dangos eto.
+      table:
+        name: "seen_cookie_messages"
+        purpose: "Arbed neges i roi gwybod inni eich bod wedi gweld ein neges ynglŷn â chwcis"
+        expires: 1 mis
+    store_answers:
+      header: 3. Storio’r atebion a roesoch yn ystod eich ymweliad (gelwir hyn yn ‘sesiwn’)
+      content: Caiff cwcis sesiwn eu storio ar eich cyfrifiadur wrth ichi fynd drwy wefan, ac maent yn gadael i'r wefan wybod beth rydych wedi'i weld a'i wneud hyd yn hyn. Cwcis dros dro yw'r rhain ac fe'u dilëir yn awtomatig ychydig amser ar ôl ichi adael y wefan.
+      table:
+        name: "_et3_session"
+        purpose: Cysylltu eich sesiwn â’ch atebion
+        expires: Pan fyddwch yn cau eich porwr
+    more_secure:
+      header: 4. Gwneud y gwasanaeth yn fwy diogel
+      content: Rydym yn gosod cwcis er mwyn rhwystro hacwyr rhag addasu cynnwys y cwcis eraill a osodon ni. Mae hyn yn gwneud y gwasanaeth yn fwy diogel ac yn diogelu eich gwybodaeth bersonol.
+    table_header:
+      name: Enw
+      purpose: Pwrpas
+      expires: Dod i ben
   terms_and_conditions:
     header: Telerau ac amodau
     introduction: Trwy ddefnyddio’r gwasanaeth hwn rydych yn cytuno i’r telerau defnydd hyn. Mae hyn yn cynnwys y polisi preifatrwydd.

--- a/test_common/messaging/en.yml
+++ b/test_common/messaging/en.yml
@@ -299,6 +299,9 @@ en:
       ico_href: Information Commissioner's Office
       privacy_policy_href: privacy policy
       cookie_policy_href: cookie policy
+      managing_cookies_href: how to manage cookies
+      google_privacy_policy_href: Privacy Policy
+      opt_out_href: opt out of Google Analytics
   components:
     save_and_continue_button: Save and continue
     single_choice_option_section:
@@ -339,6 +342,59 @@ en:
     data_title: Data Protection Act 1998
     data_content: We will send a copy of this form to the claimant and the Advisory, Conciliation and Arbitration Service (ACAS). We will put the information you give us on this form onto a computer. This helps us to monitor progress and produce statistics. Information provided on this form is passed to the Department for Business, Innovation and Skills to assist research into the use and effectiveness of employment tribunals.
     start_now: Start now
+  cookies:
+    header: Cookies
+    introduction: A cookie is a small piece of data that’s stored on your computer, tablet, or phone when you visit a website. Most websites need cookies to work properly.
+    introduction_bullets:
+      - "This service uses them to:"
+      - - measure how you use the service so it can be improved
+        - remember the notifications you’ve seen so that you’re not shown them again
+        - temporarily store the answers you give
+      - Find out more about %{managing_cookies_href}
+    subheader: How cookies are used in this service
+    website_usage:
+      header: 1. To measure website usage
+      content:
+        - We use Google Analytics software to collect information about how you use this service. We do this to help make sure the service is meeting the needs of its users and to help us make improvements, for example improving site search.
+        - "Google Analytics stores information about:"
+        - - the pages you visit
+          - how long you spend on each page
+          - how you got to the service
+          - what you click on while you're visiting the service
+        - We allow Google to use or share our analytics data. You can find out more about how Google use this information in their %{google_privacy_policy_href}.
+        - You can %{opt_out_href} if you do not want Google to have access to your information.
+        - "Google Analytics sets the following cookies:"
+      table:
+        - - "_ga"
+          - This helps us count how many people visit the service by tracking if you’ve visited before
+          - 2 years
+        - - "_gat"
+          - Manages the rate page view requests are made
+          - 10 minutes
+        - - "_gid"
+          - Identifies you to the service
+          - 24 hours
+    introductory_message:
+      header: 2. To turn our introductory message off
+      content: You may see a pop-up welcome message when you first visit the service. We’ll store a cookie so that your computer knows you’ve seen it and knows not to show it again.
+      table:
+        name: "seen_cookie_messages"
+        purpose: "Saves a message to let us know that you’ve seen our cookie message"
+        expires: 1 month
+    store_answers:
+      header: 3. To store the answers you’ve given during your visit (known as a ‘session’)
+      content: Session cookies are stored on your computer as you travel through a website, and let the website know what you’ve seen and done so far. These are temporary cookies and are automatically deleted a short while after you leave the website.
+      table:
+        name: "_et3_session"
+        purpose: Temporarily links your session to your answers
+        expires: When you close your browser
+    more_secure:
+      header: 4. To make the service more secure
+      content: We set cookies which prevent attackers from modifying the contents of the other cookies we set. This makes the service more secure and protects your personal information.
+    table_header:
+      name: Name
+      purpose: Purpose
+      expires: Expires
   terms_and_conditions:
     header: Terms and conditions
     introduction: By using this service you’re agreeing to these terms of use. This includes the privacy policy.

--- a/test_common/messaging/en.yml
+++ b/test_common/messaging/en.yml
@@ -317,8 +317,9 @@ en:
       more_category_link: More from the Working, jobs and pensions category
       more_category_href: http://gov.uk/browse/working
     footer:
-      terms: Terms and conditions
       privacy: Privacy policy
+      terms: Terms and conditions
+      cookies: Cookies
     confirmation_of_supplied_details:
       remove_file_link: Remove file
   introduction:

--- a/test_common/page_objects/base_page.rb
+++ b/test_common/page_objects/base_page.rb
@@ -19,8 +19,9 @@ module ET3
         element :more_category_link, :link_named, 'components.sidebar.more_category_link'
       end
 
-      element :terms, :link_named, 'components.footer.terms'
+      element :cookies, :link_named, 'components.footer.cookies'
       element :privacy_notice, :link_named, 'components.footer.privacy'
+      element :terms, :link_named, 'components.footer.terms'
 
       def js_severe_errors
         return [] unless page.driver.try(:browser).try(:browser) == :chromedriver

--- a/test_common/page_objects/cookies_page.rb
+++ b/test_common/page_objects/cookies_page.rb
@@ -1,0 +1,99 @@
+module ET3
+  module Test
+    class CookiesPage < BasePage
+      set_url '/cookies'
+      section :switch_language, LanguageSwitcherSection, '.switch-language'
+
+      element :header, :content_header, 'cookies.header'
+
+      section :introduction, :wrapper_headered, 'cookies.introduction' do
+        include ET3::Test::I18n
+
+        def assert_content
+          t('cookies.introduction_bullets', managing_cookies_href:
+              t('links.footer.managing_cookies_href')).each do |translated_element|
+            case translated_element
+            when String
+              root_element.assert_selector('p', text: translated_element)
+            when Array
+              translated_element.each do |translated_bullet_point|
+                root_element.assert_selector('li', text: translated_bullet_point)
+              end
+            end
+          end
+        end
+      end
+
+      element :cookies_used_subheader, :element_with_text, 'cookies.subheader'
+
+      section :website_usage, :wrapper_headered, 'cookies.website_usage.header'do
+        include ET3::Test::I18n
+        element :header, :element_with_text, 'cookies.website_usage.header'
+        def assert_content
+          t('cookies.website_usage.content',
+            google_privacy_policy_href: t('links.footer.google_privacy_policy_href'),
+            opt_out_href: t('links.footer.opt_out_href')
+          ).each do |translated_element|
+            case translated_element
+            when String
+              root_element.assert_selector('p', text: translated_element)
+            when Array
+              translated_element.each do |translated_bullet_point|
+                root_element.assert_selector('li', text: translated_bullet_point)
+              end
+            end
+          end
+        end
+        def assert_table
+          t('cookies.website_usage.table').each do |translated_row|
+            translated_row.each do |translated_cell|
+              root_element.assert_selector('td', text: translated_cell)
+            end
+          end
+        end
+      end
+
+      section :introductory_message, :wrapper_headered, 'cookies.introductory_message.header'do
+        include ET3::Test::I18n
+        element :header, :element_with_text, 'cookies.introductory_message.header'
+        def assert_content
+          root_element.assert_selector('p', text: t('cookies.introductory_message.content'))
+        end
+        def assert_table
+          root_element.assert_selector('td', text: t('cookies.introductory_message.table.name')) &&
+          root_element.assert_selector('td', text: t('cookies.introductory_message.table.purpose')) &&
+          root_element.assert_selector('td', text: t('cookies.introductory_message.table.expires'))
+        end
+      end
+
+      section :store_answers, :wrapper_headered, 'cookies.store_answers.header'do
+        include ET3::Test::I18n
+        element :header, :element_with_text, 'cookies.store_answers.header'
+        def assert_content
+          root_element.assert_selector('p', text: t('cookies.store_answers.content'))
+        end
+        def assert_table
+          root_element.assert_selector('td', text: t('cookies.store_answers.table.name')) &&
+          root_element.assert_selector('td', text: t('cookies.store_answers.table.purpose')) &&
+          root_element.assert_selector('td', text: t('cookies.store_answers.table.expires'))
+        end
+      end
+
+      section :more_secure, :wrapper_headered, 'cookies.more_secure.header'do
+        include ET3::Test::I18n
+        element :header, :element_with_text, 'cookies.more_secure.header'
+        def assert_content
+          root_element.assert_selector('p', text: t('cookies.more_secure.content'))
+        end
+      end
+
+      def switch_to_welsh
+        switch_language.welsh_link.click
+      end
+
+      def switch_to_english
+        switch_language.english_link.click
+      end
+    end
+  end
+end


### PR DESCRIPTION
Adds a link to a legal cookies page in the footer with content as provided by Mia and approved by Dan