### PR TITLE
RST-1836: Clear Existing Response Data When Starting New Session

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -23,6 +23,10 @@ class ApplicationController < ActionController::Base
     { locale: I18n.locale == I18n.default_locale ? nil : I18n.locale }
   end
 
+  def clear_session_data
+    current_store.hash_store = {}
+  end
+
   private
 
   def save_current_store

--- a/app/controllers/form_submissions_controller.rb
+++ b/app/controllers/form_submissions_controller.rb
@@ -8,7 +8,7 @@ class FormSubmissionsController < ApplicationController
     @pdf_url = current_store.api_response[:data]["meta"]["BuildResponse"]["pdf_url"]
     @office_address = current_store.api_response[:data]["meta"]["BuildResponse"]["office_address"]
     @office_phone_number = current_store.api_response[:data]["meta"]["BuildResponse"]["office_phone_number"]
-    current_store.hash_store = {} if current_store.api_response[:status] == 202
+    clear_session_data if current_store.api_response[:status] == 202
   end
 
 end

--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -2,4 +2,9 @@ class StaticPagesController < ApplicationController
   def index; end
 
   def expired; end
+
+  def start_new_session
+    clear_session_data
+    redirect_to edit_respondents_details_path
+  end
 end

--- a/app/views/static_pages/index.html.slim
+++ b/app/views/static_pages/index.html.slim
@@ -25,4 +25,4 @@
     h4.heading-small = t('components.introduction.data_title')
     p = t('components.introduction.data_content')
 
-  = link_to t('components.introduction.start_now'), edit_respondents_details_path, class: 'button button-start'
+  = link_to t('components.introduction.start_now'), start_new_session_path, class: 'button button-start', method: :put

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,6 +18,7 @@ Rails.application.routes.draw do
     mount EtDropzoneUploader::Engine, at: '/api/v2/build_blob'
     # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
   end
+  put "/" => 'static_pages#start_new_session', as: 'start_new_session'
   get "/session_expired" => 'static_pages#expired'
   get "/ping" => "status#ping"
   get "/healthcheck" => "status#healthcheck"

--- a/spec/features/clear_existing_session_with_new_session_spec.rb
+++ b/spec/features/clear_existing_session_with_new_session_spec.rb
@@ -21,8 +21,8 @@ RSpec.feature "Clear existing session with new session", js: true do
     expect(respondents_details_page.contact_mobile_number_question.field.value).to eql ""
     respondents_details_page.contact_preference_question.email.assert_selector(:field, nil, checked: false)
     expect(respondents_details_page.contact_preference_question.preference_email.value).to eql ""
-    expect(respondents_details_page.contact_preference_question.post.has_checked_field?).to be false
-    expect(respondents_details_page.contact_preference_question.fax.has_checked_field?).to be false
+    respondents_details_page.contact_preference_question.post.assert_selector(:field, nil, checked: false)
+    respondents_details_page.contact_preference_question.fax.assert_selector(:field, nil, checked: false)
     expect(respondents_details_page.contact_preference_question.preference_fax.value).to eql ""
     expect(respondents_details_page.organisation_employ_gb_question.field.value).to eql ""
     respondents_details_page.organisation_more_than_one_site_question.assert_selector(:field, nil, checked: false)

--- a/spec/features/clear_existing_session_with_new_session_spec.rb
+++ b/spec/features/clear_existing_session_with_new_session_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+RSpec.feature "Clear existing session with new session", js: true do
+
+  scenario "works when clicking the 'Start now' button" do
+    start_page.load(locale: current_locale_parameter)
+    given_valid_data
+    start_a_new_et3_response
+    answer_respondents_details
+    start_a_new_et3_response
+
+    expect(respondents_details_page.case_number_question.field.value).to eql ""
+    expect(respondents_details_page.name_question.field.value).to eql ""
+    expect(respondents_details_page.contact_question.field.value).to eql ""
+    expect(respondents_details_page.building_name_question.field.value).to eql ""
+    expect(respondents_details_page.street_question.field.value).to eql ""
+    expect(respondents_details_page.town_question.field.value).to eql ""
+    expect(respondents_details_page.county_question.field.value).to eql ""
+    expect(respondents_details_page.postcode_question.field.value).to eql ""
+    expect(respondents_details_page.dx_number_question.field.value).to eql ""
+    expect(respondents_details_page.contact_number_question.field.value).to eql ""
+    expect(respondents_details_page.contact_mobile_number_question.field.value).to eql ""
+    respondents_details_page.contact_preference_question.email.assert_selector(:field, nil, checked: false)
+    expect(respondents_details_page.contact_preference_question.preference_email.value).to eql ""
+    expect(respondents_details_page.contact_preference_question.post.has_checked_field?).to be false
+    expect(respondents_details_page.contact_preference_question.fax.has_checked_field?).to be false
+    expect(respondents_details_page.contact_preference_question.preference_fax.value).to eql ""
+    expect(respondents_details_page.organisation_employ_gb_question.field.value).to eql ""
+    respondents_details_page.organisation_more_than_one_site_question.assert_selector(:field, nil, checked: false)
+    expect(respondents_details_page.organisation_more_than_one_site_question.employment_at_site_number.value).to eql ""
+  end
+
+end


### PR DESCRIPTION
If a user had partially filled in an ET3, left their computer and a new user began a "new session" within 60 minutes, the existing data would be shown.

This PR amends this behaviour so that clicking on the 'Start now' button always clears the session data.