### PR TITLE
RST-1778: Summary Page Revamp

### DIFF
--- a/app/views/confirmation_of_supplied_details/edit.html.slim
+++ b/app/views/confirmation_of_supplied_details/edit.html.slim
@@ -204,11 +204,12 @@
           td
             = link_to t('components.confirmation_of_supplied_details.back_to_top'), "#content"
     table
-      caption.heading-small  = t('components.confirmation_of_supplied_details.confirmation_of_your_representatives_details_answers.caption')
+      caption.heading-small = t('components.confirmation_of_supplied_details.confirmation_of_your_representatives_details_answers.caption')
       thead
         tr
           th = t('components.confirmation_of_supplied_details.question_header')
           th = t('components.confirmation_of_supplied_details.answer_header')
+      tbody
         tr
           td = t('helpers.fieldset.your_representatives_details.type_of_representative')
           td = translate_representative(@hash_store.dig(:your_representatives_details_answers, :type_of_representative))
@@ -284,6 +285,7 @@
         tr
           th = t('components.confirmation_of_supplied_details.question_header')
           th = t('components.confirmation_of_supplied_details.answer_header')
+      tbody
         tr
           td = t('helpers.fieldset.employers_contract_claim.make_employer_contract_claim')
           td = translate_stored_value(@hash_store.dig(:employer_contract_claim_answers, :make_employer_contract_claim),
@@ -302,6 +304,7 @@
         tr
           th = t('components.confirmation_of_supplied_details.question_header')
           th = t('components.confirmation_of_supplied_details.answer_header')
+      tbody
         tr
           td = t('helpers.label.additional_information.upload_additional_information')
           td

--- a/app/views/confirmation_of_supplied_details/edit.html.slim
+++ b/app/views/confirmation_of_supplied_details/edit.html.slim
@@ -2,9 +2,6 @@
 - content_for :page_title, raw("#{content_for :form_page_title} - Response to Claim - MoJ")
 .content-body.confirmation-of-supplied-details
 
-  h2.heading-medium = t('components.confirmation_of_supplied_details.receipt_header')
-  p = t('components.confirmation_of_supplied_details.receipt_description')
-
   = form_for @confirmation_of_supplied_details, url: confirmation_of_supplied_details_path, method: :patch  do |f|
 
     div data-turbolinks="false"
@@ -12,11 +9,6 @@
         t('errors.header'),
         t('errors.description')
 
-    = f.text_field :email_receipt
-
-    p = t('components.confirmation_of_supplied_details.submit_guidance')
-  
-    h2.heading-medium = t('components.confirmation_of_supplied_details.table_header')
     table
       caption.heading-small = t('components.confirmation_of_supplied_details.confirmation_of_respondents_details_answers.caption')
       thead
@@ -323,4 +315,7 @@
           td
             = link_to t('components.confirmation_of_supplied_details.back_to_top'), "#content"
     br
+    h2.heading-medium = t('components.confirmation_of_supplied_details.receipt_header')
+    p = t('components.confirmation_of_supplied_details.receipt_description')
+    = f.text_field :email_receipt
     = f.submit(t('components.confirmation_of_supplied_details.submit'), class: 'button')

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -194,7 +194,7 @@ cy:
       additional_information:
         upload_additional_information: "Llwythwch ffeil i ddarparu unrhyw wybodaeth ychwanegol bwysig am eich ymateb nad ydych wedi’i chynnwys hyd yma (dewisol) "
       confirmation_of_supplied_details:
-        email_receipt: "Cyfeiriad E-bost (dewisol) "
+        email_receipt: "Cyfeiriad e-bost (dewisol) "
     hint:
       respondents_detail:
         contact: "Er enghraifft, John Smith "
@@ -226,8 +226,6 @@ cy:
           NODER - Dim ond gwybodaeth gyfyngedig y gallwch roi yma (hyd at 4500 o nodau). Os hoffech gynnwys rhagor o wybodaeth, defnyddiwch y cyfleuster sydd ar ddiwedd y ffurflen hon i lwytho ffeil Rich Text Format (.rtf). Os byddwch yn ysgrifenu mwy na 50 llinell, ni fyddwch yn cael holl fanylion eich ymateb yn y PDF a fydd yn cael ei ddychwelyd atoch ar ôl ichi gyflwyno'r ffurflen.
       additional_information:
         upload_additional_information: "Math o ffeil: .rtf "
-      confirmation_of_supplied_details:
-        email_receipt: "Er enghraifft, name@address.com"
   errors:
     header: "Adolygwch y canlynol "
     description: Bydd clicio ar wall yn mynd â chi'n syth at y cwestiwn. Cywirwch y gwallau hyn cyn parhau.
@@ -297,9 +295,9 @@ cy:
       more_category_link: "Mwy o'r categori gweithio, swyddi a phensiynau "
       more_category_href: "http://gov.uk/browse/working"
     confirmation_of_supplied_details:
-      header: "Cadarnhau'r manylion a roddwyd "
+      header: Gwirio a chyflwyno eich ymateb
       receipt_header: E-bost yn cadarnhau bod y manylion wedi'u hanfon
-      receipt_description: "Nodwch eich cyfeiriad e-bost fel y gallwn anfon cadarnhad atoch"
+      receipt_description: Gallwn anfon copi o’ch derbynneb atoch drwy e-bost.
       submit_guidance: 'Bydd clicio ar "Cyflwyno Ffurflen " ar waelod y dudalen yn anfon y manylion a gadarnhawyd isod i''w prosesu.'
       table_header: "Cadarnhau'r manylion a roddwyd "
       question_header: "Cwestiwn "
@@ -325,7 +323,7 @@ cy:
         caption: "Hawliad Contract y Cyflogwr"
       confirmation_of_additional_information_answers:
         caption: "Gwybodaeth Ychwanegol "
-      submit: "Cyflwyno Ffurflen"
+      submit: Cyflwyno eich ymateb
     form_submission:
       page_title: "Cais wedi'i gwblhau "
       header: "Ymateb wedi'i gwblhau "
@@ -448,5 +446,5 @@ cy:
     make_employer_contract_claim: ydych chi eisiau gwneud Hawliad Contract y Cyflogwr?
     claim_information: rhowch gefndir a manylion eich hawliad isod. Dylech gynnwys pob dyddiad pwysig
     upload_additional_information: llwythwch ffeil i ddarparu unrhyw wybodaeth ychwanegol bwysig am eich ymateb nad ydych wedi’i chynnwys hyd yma
-    email_receipt: cyfeiriad E-bost
+    email_receipt: cyfeiriad e-bost
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -194,7 +194,7 @@ en:
       additional_information:
         upload_additional_information: Please upload a file to provide any important additional information about your response which you have not been able to include so far (optional)
       confirmation_of_supplied_details:
-        email_receipt: Email Address (optional)
+        email_receipt: Email address (optional)
     hint:
       respondents_detail:
         contact: For example, John Smith
@@ -233,8 +233,6 @@ en:
           If you exceed 50 lines you will not receive full details of your claim in the PDF returned to you on submission of the form.
       additional_information:
         upload_additional_information: "Supported file type: .rtf"
-      confirmation_of_supplied_details:
-        email_receipt: For example, name@address.com
   errors:
     header: Please review the following
     description: Clicking on an error will navigate you directly to the question. Please correct these errors before continuing.
@@ -301,10 +299,9 @@ en:
       more_category_link: More from the Working, jobs and pensions category
       more_category_href: http://gov.uk/browse/working
     confirmation_of_supplied_details:
-      header: Confirmation of Supplied Details
-      receipt_header: Email Receipt
-      receipt_description: Please enter your email address so that we can provide you with a receipt of your transaction.
-      submit_guidance: 'Pressing "Submit Form" at the foot of the page will send the details confirmed below for processing.'
+      header: Check and submit your response
+      receipt_header: Email receipt
+      receipt_description: We can email you a copy of your receipt.
       table_header: Confirmation of Supplied Details
       question_header: Question
       answer_header: Answer
@@ -329,7 +326,7 @@ en:
         caption: "Employer Contract Claim"
       confirmation_of_additional_information_answers:
         caption: "Additional Information"
-      submit: "Submit Form"
+      submit: "Submit your response"
     form_submission:
       page_title: Application Complete
       header: Response complete

--- a/test_common/messaging/cy.yml
+++ b/test_common/messaging/cy.yml
@@ -234,7 +234,7 @@ cy:
       button: "Cliciwch yma i lwytho ffeil rtf"
     # Confirmation of Supplied Details Page
     email_receipt:
-      label: Cyfeiriad E-bost (dewisol)
+      label: Cyfeiriad e-bost (dewisol)
     # Captions for Tables on CoSD Page
     table:
       caption: WELSH - Confirmation of Supplied Details
@@ -362,11 +362,10 @@ cy:
     drag_text: "Llusgwch y ffeiliau rtf a'u rhoi yma"
     or_text: "neu"
   confirmation:
-    header: "Cadarnhau'r manylion a roddwyd"
+    header: Gwirio a chyflwyno eich ymateb
     receipt_header: "Nodyn yn cadarnhau bod y neges e-bost wedi cyrraedd"
-    receipt_description: "Nodwch eich cyfeiriad e-bost fel y gallwn anfon cadarnhad atoch."
-    submit_guidance: Bydd clicio ar "Cyflwyno Ffurflen " ar waelod y dudalen yn anfon y manylion a gadarnheir isod i'w prosesu.
-    submit: Cyflwyno Ffurflen
+    receipt_description: Gallwn anfon copi o’ch derbynneb atoch drwy e-bost.
+    submit: Cyflwyno eich ymateb
   submission:
     confirmation: "Ymateb wedi'i gwblhau"
     reference: 142000000100

--- a/test_common/messaging/en.yml
+++ b/test_common/messaging/en.yml
@@ -232,7 +232,7 @@ en:
       button: Click here to upload a file
     # Confirmation of Supplied Details Page
     email_receipt:
-      label: Email Address (optional)
+      label: Email address (optional)
     # Captions for Tables on CoSD Page
     table:
       caption: Confirmation of Supplied Details
@@ -366,8 +366,6 @@ en:
         If you exceed 50 lines you will not receive full details of your claim in the PDF returned to you on submission of the form.
     additional_information:
       upload_additional_information: "Supported file type: .rtf"
-    confirmation_of_supplied_details:
-      email_receipt: For example, name@address.com
 
   respondents_details:
     header: "Respondent's Details"
@@ -392,11 +390,10 @@ en:
     drag_text: "Drag and drop .rtf files here"
     or_text: "or"
   confirmation:
-    header: Confirmation of Supplied Details
-    receipt_header: Email Receipt
-    receipt_description: Please enter your email address so that we can provide you with a receipt of your transaction.
-    submit_guidance: 'Pressing "Submit Form" at the foot of the page will send the details confirmed below for processing.'
-    submit: Submit Form
+    header: Check and submit your response
+    receipt_header: Email receipt
+    receipt_description: We can email you a copy of your receipt.
+    submit: Submit your response
   submission:
     confirmation: Response complete
     reference: 142000000100

--- a/test_common/page_objects/confirmation_of_supplied_details_page.rb
+++ b/test_common/page_objects/confirmation_of_supplied_details_page.rb
@@ -3,11 +3,7 @@ module ET3
     class ConfirmationOfSuppliedDetailsPage < BasePage
       set_url '/respond/confirmation_of_supplied_details'
       element :error_header, :error_titled, 'errors.header', exact: true
-      section :email_receipt_question, :question_labelled, 'questions.email_receipt.label', exact: false do
-        element :field, :css, 'input'
-        element :error_invalid_email, :exact_error_text, 'errors.messages.invalid_email', exact: false
-        def set(*args); field.set(*args); end
-      end
+
       section :confirmation_of_respondents_details_answers, :table_captioned, 'questions.confirmation_of_respondents_details_answers.caption', exact: true do
         section :case_number_row, :table_row_with_td_labelled, 'questions.case_number.label', exact: true do
           element :case_number_answer, :return_answer
@@ -228,6 +224,12 @@ module ET3
           element :remove_file_link, :link_named, 'components.confirmation_of_supplied_details.remove_file_link'
         end
         element :edit_page_link, :link_named, 'links.confirmation_of_supplied_details.edit_page', exact: true
+      end
+
+      section :email_receipt_question, :question_labelled, 'questions.email_receipt.label', exact: false do
+        element :field, :css, 'input'
+        element :error_invalid_email, :exact_error_text, 'errors.messages.invalid_email', exact: false
+        def set(*args); field.set(*args); end
       end
       
       element :continue_button, :submit_text, 'confirmation.submit'

--- a/test_common/page_objects/confirmation_of_supplied_details_page.rb
+++ b/test_common/page_objects/confirmation_of_supplied_details_page.rb
@@ -8,7 +8,6 @@ module ET3
         element :error_invalid_email, :exact_error_text, 'errors.messages.invalid_email', exact: false
         def set(*args); field.set(*args); end
       end
-      element :submit_guidance, :content_header, 'confirmation.submit_guidance'
       section :confirmation_of_respondents_details_answers, :table_captioned, 'questions.confirmation_of_respondents_details_answers.caption', exact: true do
         section :case_number_row, :table_row_with_td_labelled, 'questions.case_number.label', exact: true do
           element :case_number_answer, :return_answer


### PR DESCRIPTION
Updates strings and order of elements on the Confirmation of Supplied Details page.

Data was showing many users were dropping off on this page, presumably because they thought they had completed the journey. These changes aim to make it clearer that the journey has not been completed, thus decreasing exits on this page and increasing completions.