### PR TITLE
RST-1755: Move 'Contact us' from Sidebar to Footer

### DIFF
--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -36,7 +36,6 @@
             .sidebar-content
               p = link_to(t('components.sidebar.claim_link'), t('components.sidebar.claim_href'), target: :_blank)
               p = link_to(t('components.sidebar.response_link'), t('components.sidebar.response_href'), target: :_blank)
-              p = link_to(t('components.sidebar.contact_link'), t('components.sidebar.contact_href'), target: :_blank)
               p = link_to(t('components.sidebar.download_link'), t('components.sidebar.download_href'), target: :_blank)
               hr
               p = link_to(t('components.sidebar.more_category_link'), t('components.sidebar.more_category_href'), target: :_blank)

--- a/app/views/shared/_footer_links.html.slim
+++ b/app/views/shared/_footer_links.html.slim
@@ -2,4 +2,4 @@ ul
   li= link_to(t('components.footer.cookies'), cookies_path)
   li= link_to(t('components.footer.privacy'), privacy_notice_path)
   li= link_to(t('components.footer.terms'), terms_and_conditions_path)
-
+  li= link_to(t('components.footer.contact_link'), t('components.footer.contact_href'), target: :_blank)

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -288,8 +288,6 @@ cy:
       claim_href: "https://www.gov.uk/cyflwyno-hawliad-i-dribiwnlys-cyflogaeth"
       response_link: Sut i ymateb
       response_href: "https://www.gov.uk/rhywun-yn-mynd-a-chi-i-dribiwnlys-cyflogaeth"
-      contact_link: "Sut i gysylltu â ni "
-      contact_href: "https://www.gov.uk/guidance/employment-tribunal-offices-and-venues"
       download_link: "Lawrlwytho copi gwag o'r ffurflen hon "
       download_href: "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/763312/et3-cym.pdf"
       more_category_link: "Mwy o'r categori gweithio, swyddi a phensiynau "
@@ -298,6 +296,8 @@ cy:
       terms: Telerau ac amodau
       privacy: Polisi preifatrwydd
       cookies: Cwcis
+      contact_link: "Sut i gysylltu â ni "
+      contact_href: "https://www.gov.uk/guidance/employment-tribunal-offices-and-venues"
     confirmation_of_supplied_details:
       header: Gwirio a chyflwyno eich ymateb
       receipt_header: E-bost yn cadarnhau bod y manylion wedi'u hanfon

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -292,8 +292,6 @@ en:
       claim_href: https://www.gov.uk/employment-tribunals
       response_link: How to make a response
       response_href: https://www.gov.uk/being-taken-to-employment-tribunal-by-employee
-      contact_link: How to contact us
-      contact_href: https://www.gov.uk/guidance/employment-tribunal-offices-and-venues
       download_link: Download a blank copy of this form
       download_href: https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/719457/et3-eng.pdf
       more_category_link: More from the Working, jobs and pensions category
@@ -302,6 +300,8 @@ en:
       privacy: Privacy policy
       terms: Terms and conditions
       cookies: Cookies
+      contact_link: Contact us
+      contact_href: https://www.gov.uk/guidance/employment-tribunal-offices-and-venues
     confirmation_of_supplied_details:
       header: Check and submit your response
       receipt_header: Email receipt

--- a/spec/features/view_footer_spec.rb
+++ b/spec/features/view_footer_spec.rb
@@ -15,6 +15,7 @@ RSpec.feature "View Footer", js: true do
       expect(current_page).to have_link(t('components.footer.cookies'), href: cookies_path(locale: current_locale_parameter))
       expect(current_page).to have_link(t('components.footer.privacy'), href: privacy_notice_path(locale: current_locale_parameter))
       expect(current_page).to have_link(t('components.footer.terms'), href: terms_and_conditions_path(locale: current_locale_parameter))
+      expect(current_page).to have_link(t('components.footer.contact_link'), href: t('components.footer.contact_href'))
     end
   end
 
@@ -34,8 +35,8 @@ RSpec.feature "View Footer", js: true do
     expect(form_submission_page).to have_link(t('components.footer.cookies'), href: cookies_path(locale: current_locale_parameter))
     expect(form_submission_page).to have_link(t('components.footer.privacy'), href: privacy_notice_path(locale: current_locale_parameter))
     expect(form_submission_page).to have_link(t('components.footer.terms'), href: terms_and_conditions_path(locale: current_locale_parameter))
+    expect(form_submission_page).to have_link(t('components.footer.contact_link'), href: t('components.footer.contact_href'))
   end
-
 
   context "when originally on the start page" do
     let(:current_page) { ET3::Test::StartPage.new }

--- a/spec/features/view_sidebar_spec.rb
+++ b/spec/features/view_sidebar_spec.rb
@@ -8,114 +8,15 @@ RSpec.feature "View Sidebar", js: true do
     stub_build_blob_to_s3
   end
 
-  scenario "on start page" do
-    start_page.load(locale: current_locale_parameter)
+  shared_examples "on a per-page basis" do
+    scenario "will show links" do
+      current_page.load(locale: current_locale_parameter)
 
-    expect(start_page.sidebar).to have_link(t('components.sidebar.claim_link'), href: t('components.sidebar.claim_href'))
-    expect(start_page.sidebar).to have_link(t('components.sidebar.response_link'), href: t('components.sidebar.response_href'))
-    expect(start_page.sidebar).to have_link(t('components.sidebar.contact_link'), href: t('components.sidebar.contact_href'))
-    expect(start_page.sidebar).to have_link(t('components.sidebar.download_link'), href: t('components.sidebar.download_href'))
-    expect(start_page.sidebar).to have_link(t('components.sidebar.more_category_link'), href: t('components.sidebar.more_category_href'))
-  end
-
-  scenario "on respondent's details page" do
-    respondents_details_page.load(locale: current_locale_parameter)
-
-    expect(respondents_details_page.sidebar).to have_link(t('components.sidebar.claim_link'), href: t('components.sidebar.claim_href'))
-    expect(respondents_details_page.sidebar).to have_link(t('components.sidebar.response_link'), href: t('components.sidebar.response_href'))
-    expect(respondents_details_page.sidebar).to have_link(t('components.sidebar.contact_link'), href: t('components.sidebar.contact_href'))
-    expect(respondents_details_page.sidebar).to have_link(t('components.sidebar.download_link'), href: t('components.sidebar.download_href'))
-    expect(respondents_details_page.sidebar).to have_link(t('components.sidebar.more_category_link'), href: t('components.sidebar.more_category_href'))
-  end
-
-  scenario "on claimant's details page" do
-    claimants_details_page.load(locale: current_locale_parameter)
-
-    expect(claimants_details_page.sidebar).to have_link(t('components.sidebar.claim_link'), href: t('components.sidebar.claim_href'))
-    expect(claimants_details_page.sidebar).to have_link(t('components.sidebar.response_link'), href: t('components.sidebar.response_href'))
-    expect(claimants_details_page.sidebar).to have_link(t('components.sidebar.contact_link'), href: t('components.sidebar.contact_href'))
-    expect(claimants_details_page.sidebar).to have_link(t('components.sidebar.download_link'), href: t('components.sidebar.download_href'))
-    expect(claimants_details_page.sidebar).to have_link(t('components.sidebar.more_category_link'), href: t('components.sidebar.more_category_href'))
-  end
-
-  scenario "on earnings and benefits page" do
-    earnings_and_benefits_page.load(locale: current_locale_parameter)
-
-    expect(earnings_and_benefits_page.sidebar).to have_link(t('components.sidebar.claim_link'), href: t('components.sidebar.claim_href'))
-    expect(earnings_and_benefits_page.sidebar).to have_link(t('components.sidebar.response_link'), href: t('components.sidebar.response_href'))
-    expect(earnings_and_benefits_page.sidebar).to have_link(t('components.sidebar.contact_link'), href: t('components.sidebar.contact_href'))
-    expect(earnings_and_benefits_page.sidebar).to have_link(t('components.sidebar.download_link'), href: t('components.sidebar.download_href'))
-    expect(earnings_and_benefits_page.sidebar).to have_link(t('components.sidebar.more_category_link'), href: t('components.sidebar.more_category_href'))
-  end
-
-  scenario "response page" do
-    response_page.load(locale: current_locale_parameter)
-
-    expect(response_page.sidebar).to have_link(t('components.sidebar.claim_link'), href: t('components.sidebar.claim_href'))
-    expect(response_page.sidebar).to have_link(t('components.sidebar.response_link'), href: t('components.sidebar.response_href'))
-    expect(response_page.sidebar).to have_link(t('components.sidebar.contact_link'), href: t('components.sidebar.contact_href'))
-    expect(response_page.sidebar).to have_link(t('components.sidebar.download_link'), href: t('components.sidebar.download_href'))
-    expect(response_page.sidebar).to have_link(t('components.sidebar.more_category_link'), href: t('components.sidebar.more_category_href'))
-  end
-
-  scenario "your representative page" do
-    your_representative_page.load(locale: current_locale_parameter)
-
-    expect(your_representative_page.sidebar).to have_link(t('components.sidebar.claim_link'), href: t('components.sidebar.claim_href'))
-    expect(your_representative_page.sidebar).to have_link(t('components.sidebar.response_link'), href: t('components.sidebar.response_href'))
-    expect(your_representative_page.sidebar).to have_link(t('components.sidebar.contact_link'), href: t('components.sidebar.contact_href'))
-    expect(your_representative_page.sidebar).to have_link(t('components.sidebar.download_link'), href: t('components.sidebar.download_href'))
-    expect(your_representative_page.sidebar).to have_link(t('components.sidebar.more_category_link'), href: t('components.sidebar.more_category_href'))
-  end
-
-  scenario "your representative's details page" do
-    your_representatives_details_page.load(locale: current_locale_parameter)
-
-    expect(your_representatives_details_page.sidebar).to have_link(t('components.sidebar.claim_link'), href: t('components.sidebar.claim_href'))
-    expect(your_representatives_details_page.sidebar).to have_link(t('components.sidebar.response_link'), href: t('components.sidebar.response_href'))
-    expect(your_representatives_details_page.sidebar).to have_link(t('components.sidebar.contact_link'), href: t('components.sidebar.contact_href'))
-    expect(your_representatives_details_page.sidebar).to have_link(t('components.sidebar.download_link'), href: t('components.sidebar.download_href'))
-    expect(your_representatives_details_page.sidebar).to have_link(t('components.sidebar.more_category_link'), href: t('components.sidebar.more_category_href'))
-  end
-
-  scenario "disability page" do
-    disability_page.load(locale: current_locale_parameter)
-
-    expect(disability_page.sidebar).to have_link(t('components.sidebar.claim_link'), href: t('components.sidebar.claim_href'))
-    expect(disability_page.sidebar).to have_link(t('components.sidebar.response_link'), href: t('components.sidebar.response_href'))
-    expect(disability_page.sidebar).to have_link(t('components.sidebar.contact_link'), href: t('components.sidebar.contact_href'))
-    expect(disability_page.sidebar).to have_link(t('components.sidebar.download_link'), href: t('components.sidebar.download_href'))
-    expect(disability_page.sidebar).to have_link(t('components.sidebar.more_category_link'), href: t('components.sidebar.more_category_href'))
-  end
-
-  scenario "employer contract claim page" do
-    employers_contract_claim_page.load(locale: current_locale_parameter)
-
-    expect(employers_contract_claim_page.sidebar).to have_link(t('components.sidebar.claim_link'), href: t('components.sidebar.claim_href'))
-    expect(employers_contract_claim_page.sidebar).to have_link(t('components.sidebar.response_link'), href: t('components.sidebar.response_href'))
-    expect(employers_contract_claim_page.sidebar).to have_link(t('components.sidebar.contact_link'), href: t('components.sidebar.contact_href'))
-    expect(employers_contract_claim_page.sidebar).to have_link(t('components.sidebar.download_link'), href: t('components.sidebar.download_href'))
-    expect(employers_contract_claim_page.sidebar).to have_link(t('components.sidebar.more_category_link'), href: t('components.sidebar.more_category_href'))
-  end
-
-  scenario "additional information page" do
-    additional_information_page.load(locale: current_locale_parameter)
-
-    expect(additional_information_page.sidebar).to have_link(t('components.sidebar.claim_link'), href: t('components.sidebar.claim_href'))
-    expect(additional_information_page.sidebar).to have_link(t('components.sidebar.response_link'), href: t('components.sidebar.response_href'))
-    expect(additional_information_page.sidebar).to have_link(t('components.sidebar.contact_link'), href: t('components.sidebar.contact_href'))
-    expect(additional_information_page.sidebar).to have_link(t('components.sidebar.download_link'), href: t('components.sidebar.download_href'))
-    expect(additional_information_page.sidebar).to have_link(t('components.sidebar.more_category_link'), href: t('components.sidebar.more_category_href'))
-  end
-
-  scenario "confirmation of supplied details page" do
-    confirmation_of_supplied_details_page.load(locale: current_locale_parameter)
-
-    expect(confirmation_of_supplied_details_page.sidebar).to have_link(t('components.sidebar.claim_link'), href: t('components.sidebar.claim_href'))
-    expect(confirmation_of_supplied_details_page.sidebar).to have_link(t('components.sidebar.response_link'), href: t('components.sidebar.response_href'))
-    expect(confirmation_of_supplied_details_page.sidebar).to have_link(t('components.sidebar.contact_link'), href: t('components.sidebar.contact_href'))
-    expect(confirmation_of_supplied_details_page.sidebar).to have_link(t('components.sidebar.download_link'), href: t('components.sidebar.download_href'))
-    expect(confirmation_of_supplied_details_page.sidebar).to have_link(t('components.sidebar.more_category_link'), href: t('components.sidebar.more_category_href'))
+      expect(current_page.sidebar).to have_link(t('components.sidebar.claim_link'), href: t('components.sidebar.claim_href'))
+      expect(current_page.sidebar).to have_link(t('components.sidebar.response_link'), href: t('components.sidebar.response_href'))
+      expect(current_page.sidebar).to have_link(t('components.sidebar.download_link'), href: t('components.sidebar.download_href'))
+      expect(current_page.sidebar).to have_link(t('components.sidebar.more_category_link'), href: t('components.sidebar.more_category_href'))
+    end
   end
 
   scenario "form submission page" do
@@ -133,9 +34,74 @@ RSpec.feature "View Sidebar", js: true do
 
     expect(form_submission_page.sidebar).to have_link(t('components.sidebar.claim_link'), href: t('components.sidebar.claim_href'))
     expect(form_submission_page.sidebar).to have_link(t('components.sidebar.response_link'), href: t('components.sidebar.response_href'))
-    expect(form_submission_page.sidebar).to have_link(t('components.sidebar.contact_link'), href: t('components.sidebar.contact_href'))
     expect(form_submission_page.sidebar).to have_link(t('components.sidebar.download_link'), href: t('components.sidebar.download_href'))
     expect(form_submission_page.sidebar).to have_link(t('components.sidebar.more_category_link'), href: t('components.sidebar.more_category_href'))
+  end
+
+  context "when originally on the start page" do
+    let(:current_page) { ET3::Test::StartPage.new }
+
+    include_examples "on a per-page basis"
+  end
+
+  context "when originally on the respondent's details page" do
+    let(:current_page) { ET3::Test::RespondentsDetailsPage.new }
+
+    include_examples "on a per-page basis"
+  end
+
+  context "when originally on the claimant's details page" do
+    let(:current_page) { ET3::Test::ClaimantsDetailsPage.new }
+
+    include_examples "on a per-page basis"
+  end
+
+  context "when originally on the earnings and benefits page" do
+    let(:current_page) { ET3::Test::EarningsAndBenefitsPage.new }
+
+    include_examples "on a per-page basis"
+  end
+
+  context "when originally on the response page" do
+    let(:current_page) { ET3::Test::ResponsePage.new }
+
+    include_examples "on a per-page basis"
+  end
+
+  context "when originally on the your representative page" do
+    let(:current_page) { ET3::Test::ResponsePage.new }
+
+    include_examples "on a per-page basis"
+  end
+
+  context "when originally on the your representative's details page" do
+    let(:current_page) { ET3::Test::ResponsePage.new }
+
+    include_examples "on a per-page basis"
+  end
+
+  context "when originally on the disability page" do
+    let(:current_page) { ET3::Test::DisabilityPage.new }
+
+    include_examples "on a per-page basis"
+  end
+
+  context "when originally on the employer contract claim page" do
+    let(:current_page) { ET3::Test::EmployersContractClaimPage.new }
+
+    include_examples "on a per-page basis"
+  end
+
+  context "when originally on the additional information page" do
+    let(:current_page) { ET3::Test::AdditionalInformationPage.new }
+
+    include_examples "on a per-page basis"
+  end
+
+  context "when originally on the confirmation of supplied details page" do
+    let(:current_page) { ET3::Test::ConfirmationOfSuppliedDetailsPage.new }
+
+    include_examples "on a per-page basis"
   end
 
 end

--- a/test_common/messaging/cy.yml
+++ b/test_common/messaging/cy.yml
@@ -324,8 +324,6 @@ cy:
       claim_href: "https://www.gov.uk/cyflwyno-hawliad-i-dribiwnlys-cyflogaeth"
       response_link: Sut i ymateb
       response_href: "https://www.gov.uk/rhywun-yn-mynd-a-chi-i-dribiwnlys-cyflogaeth"
-      contact_link: "Sut i gysylltu â ni"
-      contact_href: "https://www.gov.uk/guidance/employment-tribunal-offices-and-venues"
       download_link: "Lawrlwytho copi gwag o'r ffurflen hon"
       download_href: "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/763312/et3-cym.pdf"
       more_category_link: "Mwy o'r categori gweithio, swyddi a phensiynau"
@@ -334,6 +332,8 @@ cy:
       terms: Telerau ac amodau
       privacy: Polisi preifatrwydd
       cookies: Cwcis
+      contact_link: "Sut i gysylltu â ni"
+      contact_href: "https://www.gov.uk/guidance/employment-tribunal-offices-and-venues"
     confirmation_of_supplied_details:
       remove_file_link: "Dileu ffeil"
   introduction:

--- a/test_common/messaging/en.yml
+++ b/test_common/messaging/en.yml
@@ -313,8 +313,6 @@ en:
       claim_href: https://www.gov.uk/employment-tribunals
       response_link: How to make a response
       response_href: https://www.gov.uk/being-taken-to-employment-tribunal-by-employee
-      contact_link: How to contact us
-      contact_href: https://www.gov.uk/guidance/employment-tribunal-offices-and-venues
       download_link: Download a blank copy of this form
       download_href: https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/719457/et3-eng.pdf
       more_category_link: More from the Working, jobs and pensions category
@@ -323,6 +321,8 @@ en:
       privacy: Privacy policy
       terms: Terms and conditions
       cookies: Cookies
+      contact_link: Contact us
+      contact_href: https://www.gov.uk/guidance/employment-tribunal-offices-and-venues
     confirmation_of_supplied_details:
       remove_file_link: Remove file
   introduction:


### PR DESCRIPTION
In English this also renames the link from "How to contact us" to "Contact us" but I don't have Welsh strings so will do those as a separate ticket, later.